### PR TITLE
Fix TLS peer wildcard matching with matching last component

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1019,7 +1019,7 @@ relpTcpChkOnePeerWildcard(tcpPermittedPeerWildcardComp_t *pRoot, char *peername,
 	 * empty. That happens frequently if the domain root (e.g. "example.com.")
 	 * is properly given.
 	 */
-	if(pWildcard->wildcardType == tcpPEER_WILDCARD_EMPTY_COMPONENT)
+	if(pWildcard != NULL && pWildcard->wildcardType == tcpPEER_WILDCARD_EMPTY_COMPONENT)
 		pWildcard = pWildcard->pNext;
 
 	if(pWildcard != NULL) {


### PR DESCRIPTION
When the last component of a wildcard match actually matches we
end up with pWildcard == NULL at the end of while(*pC). Check
for pWildcard != NULL before dereferencing it.
