### PR TITLE
Fix matching with multiple allowed peer wildcards

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1053,6 +1053,8 @@ relpTcpChkOnePeerName(relpTcp_t *pThis, char *peername, int *pbFoundPositiveMatc
 		} else {
 			relpTcpChkOnePeerWildcard(pThis->permittedPeers.peer[i].wildcardRoot,
 			        peername, pbFoundPositiveMatch);
+			if (*pbFoundPositiveMatch)
+				break;
 		}
 	}
 }


### PR DESCRIPTION
In relpTcpChkOnePeerName we need to return when relpTcpChkOnePeerWildcard
found a positive match; else pbFoundPositiveMatch will get overwritten
with the result of the _last_ wildcard's match (unless a non-wildcard
peer happens to match first).
