### PR TITLE
Send full buffers after connection re-establishing

### DIFF
--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -677,6 +677,11 @@ relpSessTryReestablish(relpSess_t *pThis)
 								   - pUnackedEtry->pSendbuf->lenTxnr);
 		CHKRet(relpFrameRewriteTxnr(pUnackedEtry->pSendbuf, pThis->txnr));
 		pThis->txnr = relpEngineNextTXNR(pThis->txnr);
+		/* Sometimes only part of large buffer is sent before
+		 * connection was closed and bufPtr is set to non-zero value,
+		 * resulting in partial transfer. We always want to send full
+		 * buffer in new connection hence this bufPtr value reset. */
+		pUnackedEtry->pSendbuf->bufPtr = 0;
 		CHKRet(relpSendbufSendAll(pUnackedEtry->pSendbuf, pThis, 0));
 		pUnackedEtry = pUnackedEtry->pNext;
 	}


### PR DESCRIPTION
When sending large buffers it's possible that only part of buffer data
will be transferred before connection is closed. Then on connection
re-establishing librelp thinks part of buffer is already sent and
transfers only remaining part. Remote side then is not be able to parse
such message and always closes the connection.

Fix this by resetting bufPtr in relpSendbuf_s before re-sending unacked
message.

Initially I've encountered this problem in rsyslog, one instance was
publishing large messages (~32k) to another via TLS connections with TLS
compression enabled and there were constant disconnects after first
connection reestablishing, all because of that partial buffer sending.