### PR TITLE
Flush the current recv frame if it exists if the client session is restarting

### DIFF
--- a/src/relpframe.h
+++ b/src/relpframe.h
@@ -66,6 +66,7 @@ struct relpFrame_s {
 
 /* prototypes */
 relpRetVal relpFrameProcessOctetRcvd(relpFrame_t **ppThis, relpOctet_t c, relpSess_t *pSess);
+relpRetVal relpFrameDestruct(relpFrame_t **ppThis);
 relpRetVal relpFrameBuildSendbuf(relpSendbuf_t **ppSendbuf, relpTxnr_t txnr, unsigned char *pCmd, size_t lenCmd,
 	   relpOctet_t *pData, size_t lenData, relpSess_t *pSess, relpRetVal (*rspHdlr)(relpSess_t*,relpFrame_t*));
 relpRetVal relpFrameRewriteTxnr(relpSendbuf_t *pSendbuf, relpTxnr_t txnr);

--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -816,6 +816,10 @@ relpSessConnect(relpSess_t *pThis, int protFamily, unsigned char *port, unsigned
 			ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
 	}
 
+	if (pThis->pCurrRcvFrame != NULL) {
+		relpFrameDestruct(&pThis->pCurrRcvFrame);
+	}
+
 	/* (re-)init some counters */
 	pThis->txnr = 1;
 	pThis->sessType = eRelpSess_Client;	/* indicate we have a client session */


### PR DESCRIPTION
Ran into an issue today where the connection to a relp server was severed before a proper frame was received by the client.

Attaching `gdb` to the process showed that `omrelp` was stuck trying to re-establish the session while the recv frame state machine was in `eRelpFrameRcvState_IN_TRAILER`

This was bad since when trying to re-establish the session, offers are sent and expected to be received by the client. Ideally `pCurrRcvFrame` on the session is null, allowing `relpFrameProcessOctetRcvd` to create a new `relpFrame_t`, and then properly process the relp server offers.