### PR TITLE
Revert "Configurable connection timeout"

### DIFF
--- a/src/librelp.h
+++ b/src/librelp.h
@@ -208,7 +208,6 @@ relpRetVal relpSrvAddPermittedPeer(relpSrv_t *pThis, char *peer);
 relpRetVal relpCltConnect(relpClt_t *pThis, int protFamily, unsigned char *port, unsigned char *host);
 relpRetVal relpCltSendSyslog(relpClt_t *pThis, unsigned char *pMsg, size_t lenMsg);
 relpRetVal relpCltSetTimeout(relpClt_t *pThis, unsigned timeout);
-relpRetVal relpCltSetConnTimeout(relpClt_t *pThis, int connTimeout);
 relpRetVal relpCltSetWindowSize(relpClt_t *pThis, int sizeWindow);
 relpRetVal relpCltSetClientIP(relpClt_t *pThis, unsigned char *ipAddr);
 relpRetVal relpCltEnableTLS(relpClt_t *pThis);

--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -59,7 +59,6 @@ relpCltConstruct(relpClt_t **ppThis, relpEngine_t *pEngine)
 	RELP_CORE_CONSTRUCTOR(pThis, Clt);
 	pThis->pEngine = pEngine;
 	pThis->timeout = 90; /* 90-second timeout is the default */
-	pThis->connTimeout = 10;
 	pThis->pUsr = NULL;
 	pThis->authmode = eRelpAuthMode_None;
 	pThis->pristring = NULL;
@@ -118,7 +117,6 @@ relpCltConnect(relpClt_t *pThis, int protFamily, unsigned char *port, unsigned c
 
 	CHKRet(relpSessConstruct(&pThis->pSess, pThis->pEngine, RELP_CLT_CONN, pThis));
 	CHKRet(relpSessSetTimeout(pThis->pSess, pThis->timeout));
-	CHKRet(relpSessSetConnTimeout(pThis->pSess, pThis->connTimeout));
 	CHKRet(relpSessSetWindowSize(pThis->pSess, pThis->sizeWindow));
 	CHKRet(relpSessSetClientIP(pThis->pSess, pThis->clientIP));
 	CHKRet(relpSessSetUsrPtr(pThis->pSess, pThis->pUsr));
@@ -192,20 +190,6 @@ relpRetVal relpCltSetTimeout(relpClt_t *pThis, unsigned timeout)
 	LEAVE_RELPFUNC;
 }
 
-/** Set the timeout value for this client socket connection.  */
-relpRetVal relpCltSetConnTimeout(relpClt_t *pThis, int connTimeout)
-{
-	ENTER_RELPFUNC;
-	RELPOBJ_assert(pThis, Clt);
-	if (connTimeout < 0) {
-		ABORT_FINALIZE(RELP_RET_ERR_INVAL);
-	}
-	if (connTimeout != 0) {
-		pThis->connTimeout = connTimeout;
-	}
-finalize_it:
-	LEAVE_RELPFUNC;
-}
 
 /** Set the local IP address to be used when acting as a client.
  */

--- a/src/relpclt.h
+++ b/src/relpclt.h
@@ -55,7 +55,6 @@ struct relpClt_s {
 	unsigned char *host;	/**< host(name) to connect to */
 	unsigned char *clientIP;/**< ip to bind to, or NULL if irrelevant */
 	unsigned timeout;	/**< session timeout */
-	int connTimeout;	/**< connection timeout */
 };
 
 

--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -826,7 +826,6 @@ relpSessConnect(relpSess_t *pThis, int protFamily, unsigned char *port, unsigned
 
 	CHKRet(relpTcpConstruct(&pThis->pTcp, pThis->pEngine, RELP_CLT_CONN, pThis->pClt));
 	CHKRet(relpTcpSetUsrPtr(pThis->pTcp, pThis->pUsr));
-	CHKRet(relpTcpSetConnTimeout(pThis->pTcp, pThis->connTimeout));
 	if(pThis->bEnableTLS) {
 		CHKRet(relpTcpEnableTLS(pThis->pTcp));
 		if(pThis->bEnableTLSZip) {
@@ -932,15 +931,6 @@ relpSessSetTimeout(relpSess_t *pThis, unsigned timeout)
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Sess);
 	pThis->timeout = timeout;
-	LEAVE_RELPFUNC;
-}
-
-relpRetVal
-relpSessSetConnTimeout(relpSess_t *pThis, int connTimeout)
-{
-	ENTER_RELPFUNC;
-	RELPOBJ_assert(pThis, Sess);
-	pThis->connTimeout = connTimeout;
 	LEAVE_RELPFUNC;
 }
 

--- a/src/relpsess.h
+++ b/src/relpsess.h
@@ -105,7 +105,6 @@ struct relpSess_s {
 	int bAutoRetry;	/**< automatically try (once) to reestablish a broken session? */
 	int sizeWindow;	/**< size of our app-level communications window */
 	unsigned timeout; /**< timeout after which session is to be considered broken */
-	int connTimeout; /**< connection timeout */
 	relpSessState_t sessState; /**< state of our session */
 	/* linked list of frames with outstanding "rsp" */
 	relpSessUnacked_t *pUnackedLstRoot;
@@ -145,7 +144,6 @@ relpRetVal relpSessGetUnacked(relpSess_t *pThis, relpSendbuf_t **ppSendbuf, relp
 relpRetVal relpSessTryReestablish(relpSess_t *pThis);
 relpRetVal relpSessSetProtocolVersion(relpSess_t *pThis, int protocolVersion);
 relpRetVal relpSessSetTimeout(relpSess_t *pThis, unsigned timeout);
-relpRetVal relpSessSetConnTimeout(relpSess_t *pThis, int connTimeout);
 relpRetVal relpSessSetWindowSize(relpSess_t *pThis, int sizeWindow);
 relpRetVal relpSessSetClientIP(relpSess_t *pThis, unsigned char *ip);
 relpRetVal relpSessEnableTLS(relpSess_t *pThis);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -421,15 +421,6 @@ relpTcpSetAuthMode(relpTcp_t *pThis, relpAuthMode_t authmode)
 }
 
 relpRetVal
-relpTcpSetConnTimeout(relpTcp_t *pThis, int connTimeout)
-{
-	ENTER_RELPFUNC;
-	RELPOBJ_assert(pThis, Tcp);
-	pThis->connTimeout = connTimeout;
-	LEAVE_RELPFUNC;
-}
-
-relpRetVal
 relpTcpSetGnuTLSPriString(relpTcp_t *pThis, char *pristr)
 {
 	ENTER_RELPFUNC;
@@ -1715,8 +1706,6 @@ relpTcpConnect(relpTcp_t *pThis, int family, unsigned char *port, unsigned char 
 	struct addrinfo *res = NULL;
 	struct addrinfo hints;
 	struct addrinfo *reslocal = NULL;
-	fd_set fdset;
-	struct timeval tv;
 
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Tcp);
@@ -1746,28 +1735,9 @@ relpTcpConnect(relpTcp_t *pThis, int family, unsigned char *port, unsigned char 
 		}
 	}
 
-	fcntl(pThis->sock, F_SETFL, O_NONBLOCK);
-	connect(pThis->sock, res->ai_addr, res->ai_addrlen);
-
-	FD_ZERO(&fdset);
-	FD_SET(pThis->sock, &fdset);
-	tv.tv_sec = pThis->connTimeout;
-	tv.tv_usec = 0;
-
-	if (select(pThis->sock + 1, NULL, &fdset, NULL, &tv) != 1) {
-		pThis->pEngine->dbgprint("connection timed out after %d seconds\n", pThis->connTimeout);
-		ABORT_FINALIZE(RELP_RET_TIMED_OUT);
-	}
-
-	int so_error;
-	socklen_t len = sizeof so_error;
-
-	getsockopt(pThis->sock, SOL_SOCKET, SO_ERROR, &so_error, &len);
-	if (so_error != 0) {
-		pThis->pEngine->dbgprint("socket has an error %d\n", so_error);
+	if(connect(pThis->sock, res->ai_addr, res->ai_addrlen) != 0) {
 		ABORT_FINALIZE(RELP_RET_IO_ERR);
 	}
-
 
 #ifdef ENABLE_TLS
 	if(pThis->bEnableTLS) {

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -104,7 +104,6 @@ typedef struct relpTcp_s {
 	int dhBits;	/**< number of bits for Diffie-Hellman key */
 	char *pristring; /**< priority string for GnuTLS */
 	relpAuthMode_t authmode;
-	int connTimeout;
 #ifdef ENABLE_TLS
 	gnutls_anon_client_credentials_t anoncred;	/**< client anon credentials */
 	gnutls_anon_server_credentials_t anoncredSrv;	/**< server anon credentials */
@@ -155,7 +154,6 @@ relpRetVal relpTcpSetPrivKey(relpTcp_t *pThis, char *cert);
 relpRetVal relpTcpSetPermittedPeers(relpTcp_t *pThis, relpPermittedPeers_t *pPeers);
 relpRetVal relpTcpRtryHandshake(relpTcp_t *pThis);
 relpRetVal relpTcpSetUsrPtr(relpTcp_t *pThis, void *pUsr);
-relpRetVal relpTcpSetConnTimeout(relpTcp_t *pThis, int connTimeout);
 relpRetVal relpTcpSetAuthMode(relpTcp_t *pThis, relpAuthMode_t authmode);
 void relpTcpHintBurstBegin(relpTcp_t *pThis);
 void relpTcpHintBurstEnd(relpTcp_t *pThis);


### PR DESCRIPTION
Reverts rsyslog/librelp#29

When applied, this patch casuses TLS connections to fail. This is visible when used together with rsyslog's testbench. Test ```sndrcv_relp_tls.sh``` then returns theses results:

```
------------------------------------------------------------
Test: ./sndrcv_relp_tls.sh
------------------------------------------------------------
rsyslogd started with pid  86613
rsyslogd started with pid  86613
rsyslogd: imrelp[13515]: error 'TLS handshake failed [gnutls error -15: An unexpected TLS packet was received.]', object  'lstn 13515: conn to clt 127.0.0.1/localhost' - input may not work as intended [v8.19.0.master try http://www.rsyslog.com/e/2353 ]
rsyslogd: imrelp[13515]: error 'TLS record write failed [gnutls error -10: The specified session has been invalidated for some reason.]', object  'lstn 13515: conn to clt 127.0.0.1/localhost' - input may not work as intended [v8.19.0.master try http://www.rsyslog.com/e/2353 ]
rsyslogd: imrelp[13515]: error 'TLS handshake failed [gnutls error -15: An unexpected TLS packet was received.]', object  'lstn 13515: conn to clt 127.0.0.1/localhost' - input may not work as intended [v8.19.0.master try http://www.rsyslog.com/e/2353 ]
rsyslogd: imrelp[13515]: error 'TLS record write failed [gnutls error -10: The specified session has been invalidated for some reason.]', object  'lstn 13515: conn to clt 127.0.0.1/localhost' - input may not work as intended [v8.19.0.master try http://www.rsyslog.com/e/2353 ]
   PID TTY          TIME CMD
 86674 pts/18   00:00:00 rsyslogd
rsyslogd2 started with pid  86674
rsyslogd2 started with pid  86674
00001 open connections
starting run 1
Sending 50000 messages.
00050000 messages sent
runtime: 0.030
00001 close connections
End of tcpflood Run
Shutting down instance 2
imdiag[13501]: mainqueue empty
imdiag[13500]: mainqueue empty
cp: no se puede efectuar `stat' sobre 'rsyslog.out.log': No existe el archivo o el directorio
/home/rger/proj/rsyslog/tests/diag.sh: línea 347: rsyslog.out.log: No existe el archivo o el directorio
error opening file 'work'
work: No such file or directory
sequence error detected
FAIL!
```

Note that this failure occurs in about 50% of the cases, not all. It happens on slow and fast machines. Tested on Fedora 23 and Ubuntu 16.04LTS.