### PR TITLE
fix potential segfault when high-numbered fd is used in sender

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,6 @@ AC_TYPE_SIZE_T
 AC_CHECK_MEMBERS([struct sockaddr.sa_len],,,[$sa_includes])
 
 # Checks for library functions.
-AC_FUNC_MALLOC
 AC_FUNC_SELECT_ARGTYPES
 AC_FUNC_STRERROR_R
 AC_TYPE_SIGNAL


### PR DESCRIPTION
When a fd (socket) with value >= 1024 was used by the client sender
process, the library could segfault in select(). This depended a bit
on the platform.

This patch solves the issue by replacing the select() call with
poll(). Note that we do not changed to epoll(), because
(a) we only wait on a single fd
(b) poll() is more portable

closes https://github.com/rsyslog/librelp/issues/38