### PR TITLE
Fix duplicate lines after rsyslog-server restart

### DIFF
--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -493,11 +493,6 @@ relpSessWaitState(relpSess_t *const pThis, const relpSessState_t stateExpected, 
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Sess);
 
-	/* are we already ready? */
-	if(pThis->sessState == stateExpected || pThis->sessState == eRelpSessState_BROKEN) {
-		FINALIZE;
-	}
-
 	/* first read any outstanding data and process the packets. Note that this
 	 * call DOES NOT block.
 	 */
@@ -505,7 +500,7 @@ relpSessWaitState(relpSess_t *const pThis, const relpSessState_t stateExpected, 
 	if(localRet != RELP_RET_OK && localRet != RELP_RET_SESSION_BROKEN)
 		ABORT_FINALIZE(localRet);
 
-	/* re-check if we are already in the desired state. If so, we can immediately
+	/* check if we are already in the desired state. If so, we can immediately
 	 * return. That saves us doing a costly clock call to set the timeout. As a
 	 * side-effect, the timeout is actually applied without the time needed for
 	 * above reception. I think is is OK, even a bit logical ;)


### PR DESCRIPTION
Hello

This fixes #47 

relpSessWaitState is used by relpSessSendCommand to check server responses. Unfortunately, the step where the socket is read is actually never reached because of an early exit path introduced by commit f9d9b263500eb8b8ce65d440a103fdad597146d6. So the RELP client piles up unacked messages.
Also the client doesn't notice immediately that the socket is broken after server restart because it never gets the serverclose command.

After reverting this commit, the client processes the server response of last message before sending subsequent messages, so the unacked list stays up-to-date and there is no more duplicates after connection restart. Moreover it makes rsyslog able to handle serverclose commands.

dud