### PR TITLE
bugfix: error message on session open is truncated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   - git clone https://github.com/rsyslog/rsyslog.git
   - cd rsyslog
   - autoreconf -fvi
-  - ./configure --enable-testbench --enable-relp --enable-omrelp-default-port=13515 --enable-imdiag
+  - ./configure --enable-testbench --enable-relp --enable-omrelp-default-port=13515 --enable-imdiag --enable-omstdout
   - make
   - cd tests
   - export LD_LIBRARY_PATH=/usr/local/lib

--- a/src/copen.c
+++ b/src/copen.c
@@ -134,7 +134,9 @@ BEGINcommand(S, Init)
 	pSess->pEngine->dbgprint("in open command handler\n");
 
 	if(pSess->bServerConnOpen) {
-		relpSessSendResponse(pSess, pFrame->txnr, (unsigned char*) "500 connection already open", 20);
+		relpSessSendResponse(pSess, pFrame->txnr,
+		(unsigned char*) "500 connection already open",
+		sizeof("500 connection already open") - 1);
 		ABORT_FINALIZE(RELP_RET_SESSION_OPEN);
 	}
 


### PR DESCRIPTION
The "connection already open" error message when trying to open
an already open connection was truncated due to too-small size
specified.

Thanks to rsyslog formum user AlanR for the problem report.