### PR TITLE
fix invalid assert predicate

### DIFF
--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -648,7 +648,7 @@ relpSessTryReestablish(relpSess_t *pThis)
 
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Sess);
-	assert(pThis->sessState = eRelpSessState_BROKEN);
+	assert(pThis->sessState == eRelpSessState_BROKEN);
 
 	CHKRet(relpTcpAbortDestruct(&pThis->pTcp));
 	CHKRet(relpSessConnect(pThis, pThis->protFamily, pThis->srvPort, pThis->srvAddr));


### PR DESCRIPTION
this for should should not have been an assignment

thanks to github user KatMisato for alerting us

fixes https://github.com/rsyslog/librelp/issues/66