### PR TITLE
configure: Fix valgrind usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,16 +176,20 @@ fi
 
 # valgrind
 AC_ARG_ENABLE(valgrind,
-        [AS_HELP_STRING([--enable-valgrind],[Enable valgrind tests@<:@default=yes@:>@])],
+        [AS_HELP_STRING([--enable-valgrind],[Enable valgrind tests@<:@default=no@:>@])],
         [case "${enableval}" in
          yes) enable_valgrind="yes" ;;
           no) enable_valgrind="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-valgrind) ;;
          esac],
-        [enable_valgrind="yes"]
+        [enable_valgrind="no"]
 )
 if test "$enable_valgrind" = "yes"; then
         AC_CHECK_PROG(VALGRIND, [valgrind], [valgrind], [no])
+
+        if test "x$VALGRIND" = "xno"; then
+                AC_MSG_ERROR([valgrind is missing but forced with --enable-valgrind. Either install valgrind or remove the option!])
+        fi
 fi
 AM_CONDITIONAL([HAVE_VALGRIND], test "$enable_valgrind" == "yes")
 


### PR DESCRIPTION
Valgrind will now only used when explicitly requested via "--enable-valgrind" configure switch. Therefore, if requested but valgrind isn't available, configure will fail with an error.

Fixes: 88600be7bb55 ("testbench: valgrind can be disabled in configure")
Fixes: https://github.com/rsyslog/librelp/issues/100