### PR TITLE
replace strerror() by portable equivalent

### DIFF
--- a/src/relp.c
+++ b/src/relp.c
@@ -69,9 +69,8 @@ relpEngineCallOnGenericErr(relpEngine_t *pThis, char *eobj, relpRetVal ecode, ch
 	}
 }
 
-#if defined(HAVE_EPOLL_CREATE1) || defined(HAVE_EPOLL_CREATE)
-static char *
-relpEngine_strerror_r(int errnum, char *buf, size_t buflen) {
+const char *
+_relpEngine_strerror_r(const int errnum, char *buf, const size_t buflen) {
 #ifndef HAVE_STRERROR_R
 	char *p;
 	p = strerror(errnum);
@@ -92,6 +91,7 @@ relpEngine_strerror_r(int errnum, char *buf, size_t buflen) {
 	return buf;
 }
 
+#if defined(HAVE_EPOLL_CREATE1) || defined(HAVE_EPOLL_CREATE)
 static relpRetVal
 addToEpollSet(relpEngine_t *pThis, epolld_type_t typ, void *ptr, int sock, epolld_t **pepd)
 {
@@ -111,7 +111,7 @@ addToEpollSet(relpEngine_t *pThis, epolld_type_t typ, void *ptr, int sock, epoll
 		int eno = errno;
 		relpEngineCallOnGenericErr(pThis, "librelp", RELP_RET_ERR_EPOLL_CTL,
 			"os error (%d) during EPOLL_CTL_ADD: %s",
-			eno, relpEngine_strerror_r(eno, errStr, sizeof(errStr)));
+			eno, _relpEngine_strerror_r(eno, errStr, sizeof(errStr)));
 		ABORT_FINALIZE(RELP_RET_ERR_EPOLL_CTL);
 	}
 	*pepd = epd;
@@ -136,7 +136,7 @@ delFromEpollSet(relpEngine_t *pThis, epolld_t *epd)
 		int eno = errno;
 		relpEngineCallOnGenericErr(pThis, "librelp", RELP_RET_ERR_EPOLL_CTL,
 			"os error (%d) during EPOLL_CTL_DEL: %s",
-			eno, relpEngine_strerror_r(eno, errStr, sizeof(errStr)));
+			eno, _relpEngine_strerror_r(eno, errStr, sizeof(errStr)));
 	}
 	free(epd);
 }
@@ -621,7 +621,7 @@ epoll_set_events(relpEngine_t *pThis, relpEngSessLst_t *pSessEtry, int sock, uin
 			int eno = errno;
 			relpEngineCallOnGenericErr(pThis, "librelp", RELP_RET_ERR_EPOLL_CTL,
 				"os error (%d) during EPOLL_CTL_MOD: %s",
-				eno, relpEngine_strerror_r(eno, errStr, sizeof(errStr)));
+				eno, _relpEngine_strerror_r(eno, errStr, sizeof(errStr)));
 			ABORT_FINALIZE(RELP_RET_ERR_EPOLL_CTL);
 		}
 	}

--- a/src/relp.h
+++ b/src/relp.h
@@ -234,5 +234,6 @@ static inline int relpEngineShouldStop(relpEngine_t *pThis) {
 relpRetVal relpEngineDispatchFrame(relpEngine_t *pThis, relpSess_t *pSess, relpFrame_t *pFrame);
 void __attribute__((format(printf, 4, 5))) relpEngineCallOnGenericErr(relpEngine_t *pThis,
 	char *eobj, relpRetVal ecode, char *fmt, ...);
+const char * _relpEngine_strerror_r(const int errnum, char *buf, const size_t buflen);
 
 #endif /* #ifndef RELP_H_INCLUDED */

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1752,10 +1752,10 @@ relpTcpAcceptConnReq(relpTcp_t **ppThis, const int sock, relpSrv_t *const pSrv)
 	assert(ppThis != NULL);
 
 	iNewSock = accept(sock, (struct sockaddr*) &addr, &addrlen);
-	int errnosave = errno;
 	if(iNewSock < 0) {
-		pSrv->pEngine->dbgprint("error during accept, sleeping 20ms: %s\n",
-			strerror(errnosave));
+		char errStr[1024];
+		_relpEngine_strerror_r(errno, errStr, sizeof(errStr));
+		pSrv->pEngine->dbgprint("error during accept, sleeping 20ms: %s\n", errStr);
 		doSleep(0, 20000);
 		pSrv->pEngine->dbgprint("END SLEEP\n");
 		ABORT_FINALIZE(RELP_RET_ACCEPT_ERR);
@@ -3055,7 +3055,9 @@ relpTcpConnect(relpTcp_t *const pThis,
 	}
 	if(connect(pThis->sock, res->ai_addr, res->ai_addrlen) == -1) {
 		if(errno != EINPROGRESS) {
-			snprintf(errmsg, sizeof(errmsg), "error connecting: '%s'", strerror(errno));
+			char errStr[1024];
+			_relpEngine_strerror_r(errno, errStr, sizeof(errStr));
+			snprintf(errmsg, sizeof(errmsg), "error connecting: '%s'", errStr);
 			callOnErr(pThis, errmsg, RELP_RET_IO_ERR);
 			ABORT_FINALIZE(RELP_RET_IO_ERR);
 		}


### PR DESCRIPTION
see also https://github.com/rsyslog/librelp/pull/106
closes https://github.com/rsyslog/librelp/issues/108