### PR TITLE
do not expose symbols that are not part of public API

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,6 @@ librelp_la_CPPFLAGS = $(AM_CLFAGS) $(PTHREADS_CFLAGS) $(GNUTLS_CFLAGS) $(OPENSSL
 librelp_la_LIBADD = $(rt_libs) $(GNUTLS_LIBS) $(OPENSSL_LIBS)
 # info on version-info:
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-librelp_la_LDFLAGS = -version-info 4:0:4
+librelp_la_LDFLAGS = -version-info 4:0:4 -export-symbols-regex '^relp'
 
 include_HEADERS = librelp.h


### PR DESCRIPTION
closes https://github.com/rsyslog/librelp/issues/99