### PR TITLE
handle EAGAIN properly

### DIFF
--- a/src/librelp.h
+++ b/src/librelp.h
@@ -156,6 +156,7 @@ typedef enum relpCmdEnaState_e relpCmdEnaState_t;
 #define RELP_RET_ERR_NO_TLS	RELPERR_BASE + 45	/**< librelp compiled without TLS support */
 #define RELP_RET_ERR_NO_TLS_AUTH RELPERR_BASE + 46	/**< platform does not provide TLS auth support */
 #define RELP_RET_SESSION_OPEN	RELPERR_BASE + 47	/**< RELP session is (already) open */
+#define RELP_RET_EAGAIN		RELPERR_BASE + 48	/**< I/O operation would block; try again later */
 
 /* relp frame oversize modes */
 #define RELP_OVERSIZE_ABORT 0				/**< abort connection on oversize frame */

--- a/src/sendbuf.c
+++ b/src/sendbuf.c
@@ -130,7 +130,9 @@ relpSendbufSend(relpSendbuf_t *pThis, relpTcp_t *pTcp)
 
 	CHKRet(relpTcpSend(pTcp, pThis->pData + (9 - pThis->lenTxnr) + pThis->bufPtr, &lenWritten));
 
-	if(lenWritten != lenToWrite) {
+	if(lenWritten == 0) {
+		iRet = RELP_RET_EAGAIN;
+	} else if(lenWritten != lenToWrite) {
 		pThis->bufPtr += lenWritten;
 		iRet = RELP_RET_PARTIAL_WRITE;
 	}

--- a/src/sendq.c
+++ b/src/sendq.c
@@ -253,6 +253,11 @@ relpSendqSend(relpSendq_t *pThis, relpTcp_t *pTcp)
 			 */
 			CHKRet(relpSendqDelFirstBuf(pThis));
 			pEntry = pThis->pRoot; /* as we deleted from the root, the is our next entry */
+		} else if(localRet == RELP_RET_EAGAIN) {
+			/* The underlying socket is no longer accepting writes.
+			* Try again later (after select/epoll).
+			*/
+			break;
 		} else if(localRet != RELP_RET_PARTIAL_WRITE) {
 			ABORT_FINALIZE(localRet);
 		}


### PR DESCRIPTION
It's not clear whether we're going to continue using imrelp at Fastly, but this should fix the bug discussed in #13.

fixes https://github.com/rsyslog/librelp/issues/13