### PR TITLE
add test for duplicate receiver error

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,7 +11,8 @@ send_LDADD=../src/.libs/librelp.la
 send_CFLAGS=$(AM_CFLAGS) -I${top_srcdir}/src $(WARN_CFLAGS)
 
 VALGRIND_TESTS= \
-	tls-basic-vg.sh
+	tls-basic-vg.sh \
+	duplicate-receiver-vg.sh
 
 TESTS=  basic.sh \
 	tls-basic-anon.sh \

--- a/tests/duplicate-receiver-vg.sh
+++ b/tests/duplicate-receiver-vg.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+if [ `uname` = "SunOS" ] ; then
+   echo "This test currently does not work on all flavors of Solaris."
+   exit 77
+fi
+if [ `uname` = "FreeBSD" ] ; then
+   echo "This test currently does not work on FreeBSD."
+   exit 77
+fi
+
+. ${srcdir}/test-framework.sh
+
+startup_receiver_valgrind
+startup_receiver_valgrind
+
+echo 'Send Message...'
+./send -t 127.0.0.1 -p $TESTPORT -m "testmessage"
+
+stop_receiver
+check_output "testmessage"
+terminate


### PR DESCRIPTION
In rsyslog configuring two identical relp receiver leads
to an error. The test checks that everything is working
fine within librelp.

See: https://github.com/rsyslog/rsyslog/issues/2874