### PR TITLE
fix commit dd59c925ec631a4e1cfa082c76a30de30908ca14

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -854,7 +854,7 @@ relpTcpSetRemHost(relpTcp_t *const pThis, struct sockaddr *pAddr)
 	relpEngine_t *pEngine;
 	int error;
 	unsigned char szIP[NI_MAXHOST] = "";
-	unsigned char szHname[1045] = "";
+	unsigned char szHname[NI_MAXHOST+64] = ""; /* 64 extra bytes for message text */
 	struct addrinfo hints, *res;
 	size_t len;
 


### PR DESCRIPTION
We cannot use a fixed number for NI_HOSTNAME, as this may be different
on different platforms. But we know how much data we add, so we can
increase the value accordingly.