### PR TITLE
testbench: Fixed message detection for multiple tls tests.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,19 +15,23 @@ VALGRIND_TESTS= \
 	duplicate-receiver-vg.sh
 
 TESTS=  basic.sh \
-	tls-basic-anon.sh \
 	tls-basic.sh \
+	tls-basic-anon.sh \
 	tls-basic-fingerprint.sh \
-	tls-wrong-permittedPeer.sh \
-	tls-wrong-authname.sh \
-	tls-wrong-signedcert.sh \
-	tls-basic-brokencert.sh \
 	tls-missing-param-sender.sh \
 	tls-missing-param-receiver.sh \
 	long-msg.sh \
 	oversize-msg-abort-errmsg.sh \
 	oversize-msg-accept-errmsg.sh \
 	truncate-oversize-msg.sh
+# OpenSSL tests only!
+if ENABLE_TLS_OPENSSL
+TESTS += tls-wrong-permittedPeer.sh \
+	tls-wrong-authname.sh \
+	tls-wrong-signedcert.sh
+# reenable tests when stable
+#	tls-basic-brokencert.sh
+endif
 
 if HAVE_VALGRIND
 TESTS += $(VALGRIND_TESTS)

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -7,7 +7,7 @@
 TB_TIMEOUT_STARTUP=400  # 40 seconds - Solaris sometimes needs this...
 TESTPORT=31514
 export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
-export OPT_VERBOSE=-v # We need verbose now for propper error checking!
+#	 export OPT_VERBOSE=-v # uncomment for debugging 
 
 ######################################################################
 # functions
@@ -76,7 +76,7 @@ function check_output() {
 	else
 		FILE_TO_CHECK="$2"
 	fi
-	grep "$EXPECTED" $FILE_TO_CHECK > /dev/null
+	grep $3 "$EXPECTED" $FILE_TO_CHECK > /dev/null
 	if [ $? -ne 0 ]; then
 		printf "\nFAIL: expected message not found. Expected:\n"
 		printf "%s\n" "$EXPECTED"

--- a/tests/tls-basic-anon.sh
+++ b/tests/tls-basic-anon.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 . ${srcdir}/test-framework.sh
-startup_receiver -T
+startup_receiver -T -e error.out.log
 
 echo 'Send Message...'
 ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T $OPT_VERBOSE 1>>librelp.out.log 2>&1

--- a/tests/tls-basic-brokencert.sh
+++ b/tests/tls-basic-brokencert.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
+# ***
+# *** TEST currently UNSTABLE because SSL Server sometimes discard connection before certificate can even be checked for length!
+# ***
 . ${srcdir}/test-framework.sh
 startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ossl-ca.pem -y ${srcdir}/tls-certs/ossl-server-cert.pem -z ${srcdir}/tls-certs/ossl-server-key.pem -P 'clientbrok.testbench.rsyslog.com' -e error.out.log
 
 echo 'Send Message...'
-./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ossl-ca.pem -y ${srcdir}/tls-certs/ossl-clientbrok-cert.pem -z ${srcdir}/tls-certs/ossl-clientbrok-key.pem -P 'server.testbench.rsyslog.com' $OPT_VERBOSE 1>>librelp.out.log 2>&1
+./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ossl-ca.pem -y ${srcdir}/tls-certs/ossl-clientbrok-cert.pem -z ${srcdir}/tls-certs/ossl-clientbrok-key.pem -P 'server.testbench.rsyslog.com' -e error.out.log $OPT_VERBOSE 1>>librelp.out.log 2>&1
 
 stop_receiver
-
-if check_output_only "certificate validation failed, names inside certifcate are way to long" error.out.log; then
-	printf "\nExpected: certificate validation failed due broken client cert.\n"
-else
-	printf "\nOpenSSL Version has limited key exchange, broken certs above 32K won't work anyway.\n"
-	printf "\nDEBUG: content of librelp.out.log\n"
-	cat $FILE_TO_CHECK
-	check_output "relpTcpLastSSLErrorMsg\: Errorstack\: error\:.*\:excessive message size" error.out.log
-fi
-
+check_output "certificate validation failed, names inside certifcate are way to long" error.out.log
 terminate

--- a/tests/tls-basic-fingerprint.sh
+++ b/tests/tls-basic-fingerprint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 . ${srcdir}/test-framework.sh
-startup_receiver -T -a "fingerprint" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3'
+startup_receiver -T -a "fingerprint" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3' -e error.out.log
 
 echo 'Send Message...'
 ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "fingerprint" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3' $OPT_VERBOSE 1>>librelp.out.log 2>&1

--- a/tests/tls-basic-vg.sh
+++ b/tests/tls-basic-vg.sh
@@ -11,7 +11,7 @@ fi
 . ${srcdir}/test-framework.sh
 
 echo 'Start Receiver...'
-startup_receiver_valgrind -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P "rsyslog-client"
+startup_receiver_valgrind -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P "rsyslog-client" -e error.out.log
 
 echo 'Send Message...'
 $valgrind ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P "rsyslog-client" $OPT_VERBOSE 1>>librelp.out.log 2>&1

--- a/tests/tls-basic.sh
+++ b/tests/tls-basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 . ${srcdir}/test-framework.sh
-startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com'
+startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' -e error.out.log
 
 echo 'Send Message...'
 ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' $OPT_VERBOSE

--- a/tests/tls-wrong-authname.sh
+++ b/tests/tls-wrong-authname.sh
@@ -7,5 +7,4 @@ check_output "relpSrvSetAuthMode(pRelpSrv, authMode)"
 echo 'Send Message...'
 ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "anon" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P "rsyslog" $OPT_VERBOSE 1>>client.err.log 2>&1
 check_output "relpCltSetAuthMode(pRelpClt, authMode)" client.err.log
-
 terminate

--- a/tests/tls-wrong-permittedPeer.sh
+++ b/tests/tls-wrong-permittedPeer.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 . ${srcdir}/test-framework.sh
-startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P "wrong name"
+startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P "wrong name" -e error.out.log
 
 echo 'Send Message...'
 ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P "wrong name" $OPT_VERBOSE 1>>librelp.out.log 2>&1
 
 stop_receiver
-
-check_output "librelp\: auth error\: authdata\:'DNSname\: testbench.rsyslog.com\; "
-
+check_output "authentication error.*no permited name found.*testbench.rsyslog.com" error.out.log
 terminate

--- a/tests/tls-wrong-signedcert.sh
+++ b/tests/tls-wrong-signedcert.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 . ${srcdir}/test-framework.sh
-startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ossl-ca.pem -y ${srcdir}/tls-certs/ossl-server-cert.pem -z ${srcdir}/tls-certs/ossl-server-key.pem -P 'client.testbench.rsyslog.com'
+startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ossl-ca.pem -y ${srcdir}/tls-certs/ossl-server-cert.pem -z ${srcdir}/tls-certs/ossl-server-key.pem -P 'client.testbench.rsyslog.com' -e error.out.log
 
 echo 'Send Message...'
 ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'server.testbench.rsyslog.com' $OPT_VERBOSE 1>>librelp.out.log 2>&1
 
 stop_receiver
-check_output "librelp\: auth error\: authdata\:.*, ecode 10036"
+# Perform multiline GREP with -z
+check_output "authentication error.*signed certificate in certificate chain" error.out.log -z
 terminate


### PR DESCRIPTION
Disabled certificate check tests for GNUTLS due useless error output.
Implemented -e parameter in send.c tester utility.
Removed verbose option from test framework, not needed anymore.