### PR TITLE
be strict with multiple open commands

### DIFF
--- a/src/copen.c
+++ b/src/copen.c
@@ -134,15 +134,14 @@ BEGINcommand(S, Init)
 	pSess->pEngine->dbgprint("in open command handler\n");
 
 	if(pSess->bServerConnOpen) {
-		/* work around for cases where librelp invalidly sents open commands
-		 * inside active sessions. This is considered harmless. 2018-11-16 rgerhards */
 		if(pSess->pEngine->onErr) { // TODO: generalize!
 			pSess->pEngine->onErr(pSess->pUsr, "session", "received session open "
-				"request for already open session - ignored", RELP_RET_INVALID_FRAME);
+				"request for already open session - aborting session",
+				RELP_RET_INVALID_FRAME);
 		}
-		unsigned char replymsg[] = "200 connection already open - ignored";
+		unsigned char replymsg[] = "500 protocol error: connection already open";
 		relpSessSendResponse(pSess, pFrame->txnr, replymsg, sizeof(replymsg) - 1);
-		FINALIZE;
+		ABORT_FINALIZE(RELP_RET_SESSION_OPEN);
 	}
 
 	CHKRet(relpOffersConstructFromFrame(&pCltOffers, pFrame));


### PR DESCRIPTION
Commit 1deb7c6936a539ee16d13867e6f1cafa5286491f tried to handle
multiple open commands gracefully in the hope to enable new servers
to handle (faulty) old clients. Unfortunately, this did not work
out as the client became stuck inside it's state machine. The way
the client code is structured, it cannot advance from INIT_DONE
to READY_TO_SEND. As the whole point of the relaxed condition was
to avoid client changes, the idea does not make any sense.

Instead 1deb7c6936a539ee16d13867e6f1cafa5286491f has fixed the
root cause, and so we can keep strict, just as the RELP spec
requires us.