### PR TITLE
bugfix: user pointer internally assigned to late, could lead to user …

### DIFF
--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -116,12 +116,11 @@ relpCltConnect(relpClt_t *pThis, int protFamily, unsigned char *port, unsigned c
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Clt);
 
-	CHKRet(relpSessConstruct(&pThis->pSess, pThis->pEngine, RELP_CLT_CONN, pThis));
+	CHKRet(relpSessConstruct(&pThis->pSess, pThis->pEngine, RELP_CLT_CONN, pThis, pThis->pUsr));
 	CHKRet(relpSessSetTimeout(pThis->pSess, pThis->timeout));
 	CHKRet(relpSessSetConnTimeout(pThis->pSess, pThis->connTimeout));
 	CHKRet(relpSessSetWindowSize(pThis->pSess, pThis->sizeWindow));
 	CHKRet(relpSessSetClientIP(pThis->pSess, pThis->clientIP));
-	CHKRet(relpSessSetUsrPtr(pThis->pSess, pThis->pUsr));
 	if(pThis->bEnableTLS) {
 		CHKRet(relpSessEnableTLS(pThis->pSess));
 		if(pThis->bEnableTLSZip) {

--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -105,7 +105,7 @@ relpSessFreePermittedPeers(relpSess_t *pThis)
  *  the pSrv parameter may be set to NULL if the session object is for a client.
  */
 relpRetVal
-relpSessConstruct(relpSess_t **ppThis, relpEngine_t *pEngine, int connType, void *pParent)
+relpSessConstruct(relpSess_t **ppThis, relpEngine_t *pEngine, int connType, void *pParent, void *pUsr)
 {
 	relpSess_t *pThis;
 
@@ -118,6 +118,7 @@ relpSessConstruct(relpSess_t **ppThis, relpEngine_t *pEngine, int connType, void
 	}
 
 	RELP_CORE_CONSTRUCTOR(pThis, Sess);
+	pThis->pUsr = pUsr;
 	pThis->pEngine = pEngine;
 	/* use Engine's command enablement states as default */
 	pThis->stateCmdSyslog = pEngine->stateCmdSyslog;
@@ -128,7 +129,6 @@ relpSessConstruct(relpSess_t **ppThis, relpEngine_t *pEngine, int connType, void
 	}
 	pThis->txnr = 1; /* txnr start at 1 according to spec */
 	pThis->timeout = 90;
-	pThis->pUsr = NULL;
 	pThis->sizeWindow = RELP_DFLT_WINDOW_SIZE;
 	pThis->maxDataSize = RELP_DFLT_MAX_DATA_SIZE;
 	pThis->authmode = eRelpAuthMode_None;
@@ -231,7 +231,8 @@ relpSessAcceptAndConstruct(relpSess_t **ppThis, relpSrv_t *pSrv, int sock)
 	RELPOBJ_assert(pSrv, Srv);
 	assert(sock >= 0);
 
-	CHKRet(relpSessConstruct(&pThis, pSrv->pEngine, RELP_SRV_CONN, pSrv));
+	CHKRet(relpSessConstruct(&pThis, pSrv->pEngine, RELP_SRV_CONN, pSrv, pSrv->pUsr));
+
 	CHKRet(relpTcpAcceptConnReq(&pThis->pTcp, sock, pSrv));
 	CHKRet(relpSessSetMaxDataSize(pThis, pSrv->maxDataSize));
 

--- a/src/relpsess.h
+++ b/src/relpsess.h
@@ -132,7 +132,7 @@ relpSessTcpRequiresRtry(relpSess_t *pThis)
 }
 
 /* prototypes */
-relpRetVal relpSessConstruct(relpSess_t **ppThis, relpEngine_t *pEngine, int connType, void *pParent);
+relpRetVal relpSessConstruct(relpSess_t **ppThis, relpEngine_t *pEngine, int connType, void *pParent, void*pUsr);
 relpRetVal relpSessDestruct(relpSess_t **ppThis);
 relpRetVal relpSessAcceptAndConstruct(relpSess_t **ppThis, relpSrv_t *pSrv, int sock);
 relpRetVal relpSessRcvData(relpSess_t *pThis);


### PR DESCRIPTION
…segfault

When errors occurred early in object creation, the user pointer was not always
properly set and defaulted to NULL. If now an error was reported for some of
these errors, the NULL pointer was passed to the user application. If it
set a user pointer and tried to process it, it would segfault (or otherwise
malfunction).

The problem was not detected until recently, when we began to provide better
error messages.