### PR TITLE
change to new versioning scheme

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 ----------------------------------------------------------------------
-Version 1.2.19 - 2018-??-??
+Version 1.3.0 - 2018-??-??
 - improved error reporting
 - bugfix openssl: anon mode did not work with openssl 1.1.0+
   This was caused by "hardening" inside openssl, so not a real bug.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT([librelp], [1.2.19.master], [rgerhards@adiscon.com])
+AC_INIT([librelp], [1.3.0.master], [rgerhards@adiscon.com])
 
 # change to the one below if Travis has a timeout
 #AM_INIT_AUTOMAKE([subdir-objects serial-tests])


### PR DESCRIPTION
do NOT use patchlevel for minor version increments

in practice, follow rsyslog practice of

fixed-major.real-version.0