### PR TITLE
testbench: ensure "receive" tool cannot hang

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,7 +35,9 @@ OSSL_TESTS= \
 # reenable tests when stable
 #	tls-basic-brokencert.sh
 
-TESTS=  basic.sh \
+TESTS=  selftest_receive_watchdog.sh \
+	selftest_receive_usage.sh \
+	basic.sh \
 	basic-realistic.sh \
 	receiver-abort.sh \
 	long-msg.sh \
@@ -43,8 +45,7 @@ TESTS=  basic.sh \
 	oversize-msg-accept-errmsg.sh \
 	truncate-oversize-msg.sh \
 	send-noconnect.sh \
-	receive-emptyconnect.sh \
-	selftest_receive_usage.sh
+	receive-emptyconnect.sh
 if ENABLE_TLS_GENERIC
 TESTS+=$(TLS_TESTS)
 endif

--- a/tests/selftest_receive_watchdog.sh
+++ b/tests/selftest_receive_watchdog.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# written 2018-11-28 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=$(pwd)}/test-framework.sh
+printf 'starting receive, waiting for watchdog timeout to occur\n'
+./receive --watchdog-timeout 2 -p $TESTPORT &> $OUTFILE
+cat $OUTFILE
+check_output "watchdog timer expired"
+terminate


### PR DESCRIPTION
We now have a watchdog timer which auto-terminates itself after
60 secs (default) of activity. So this cannot hang on the CI, which
also means we do not need to cancel it out.

Other tools may need similar enhancement (to be checked).