### PR TITLE
tests: make dummyclient.py compatible with Python2 and Python3

### DIFF
--- a/tests/dummyclient.py
+++ b/tests/dummyclient.py
@@ -4,7 +4,7 @@ import socket
 import os
 
 port = int(os.environ['TESTPORT'])
-print "dummyclient info: opening and closing port " + str(port) + " without sending data"
+print("dummyclient info: opening and closing port " + str(port) + " without sending data")
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect(("127.0.0.1", port))
 s.close()


### PR DESCRIPTION
This small fix should make dummyclient.py support both, Python2 and Python3.