### PR TITLE
testbench: ensure tests run only when possible

### DIFF
--- a/tests/receiver-abort.sh
+++ b/tests/receiver-abort.sh
@@ -3,6 +3,7 @@
 # check that receiver abort is handled gracefully
 # of messages
 . ${srcdir:=$(pwd)}/test-framework.sh
+check_command_available timeout
 NUMMESSAGES=100000
 startup_receiver
 ./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES  --kill-on-msg 20000 --kill-pid $RECEIVE_PID $OPT_VERBOSE &

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -21,6 +21,25 @@ get_free_port() {
 python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()'
 }
 
+# check if command $1 is available - will exit 77 when not OK
+check_command_available() {
+	have_cmd=0
+	if [ "$1" == "timeout" ]; then
+		if timeout --version &>/dev/null ; then
+			have_cmd=1
+		fi
+	else
+		if command -v $1 ; then
+			have_cmd=1
+		fi
+	fi
+	if [ $have_cmd -eq 0 ] ; then
+		printf 'Testbench requires unavailable command: %s\n' "$1"
+		exit 77 # do NOT error_exit here!
+	fi
+}
+
+
 
 # $1 is name of pidfile to wait for
 wait_process_startup_via_pidfile() {

--- a/tests/tls-receiver-abort.sh
+++ b/tests/tls-receiver-abort.sh
@@ -3,7 +3,8 @@
 # check that receiver abort is handled gracefully
 # of messages
 . ${srcdir:=$(pwd)}/test-framework.sh
-NUMMESSAGES=100000
+check_command_available timeout
+export NUMMESSAGES=100000
 
 actual_test() {
 	startup_receiver


### PR DESCRIPTION
some tests require special OS commands, and cannot be run when they
are not available. This lead to false positives.