### PR TITLE
Variable undefined fix for when HAVE_STRERROR_R is defined

### DIFF
--- a/src/relp.c
+++ b/src/relp.c
@@ -74,7 +74,7 @@ _relpEngine_strerror_r(const int errnum, char *buf, const size_t buflen) {
 #ifndef HAVE_STRERROR_R
 	char *p;
 	p = strerror(errnum);
-	strncpy(buf, emsg, buflen);
+	strncpy(buf, p, buflen);
 	buf[buflen-1] = '\0';
 #else
 #	ifdef STRERROR_R_CHAR_P


### PR DESCRIPTION
I'm building this on an old system (Debian Wheezy, gcc 4.7.2) so it's not all that surprising that this bug has existed for 6 years. The 'emsg' variable comes from the above function so just some copy/paste error.

Prior to fix:
```
/bin/bash ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..  -pthread -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wall -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g -c -o librelp_la-relp.lo `test -f 'relp.c' || echo './'`relp.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -pthread -D_FORTIFY_SOURCE=2 -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wall -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g -c relp.c  -fPIC -DPIC -o .libs/librelp_la-relp.o
relp.c: In function '_relpEngine_strerror_r':
relp.c:77:15: error: 'emsg' undeclared (first use in this function)
relp.c:77:15: note: each undeclared identifier is reported only once for each function it appears in
relp.c:75:8: warning: variable 'p' set but not used [-Wunused-but-set-variable]
relp.c: In function 'engineEventLoopRun':
relp.c:866:13: warning: unused variable 'localRet' [-Wunused-variable]
make[2]: *** [librelp_la-relp.lo] Error 1
```

There was also an issue with a C99 declaration in tcp.c line 755 of `int i` in the for loop causing a compile time error that I did not address here with a fix. Not sure how you feel about that one.