### PR TITLE
Add support for using SSL_CONF_cmd API (openssl)

### DIFF
--- a/src/librelp.h
+++ b/src/librelp.h
@@ -235,6 +235,7 @@ relpRetVal relpSrvSetCACert(relpSrv_t *pThis, char *cert);
 relpRetVal relpSrvSetOwnCert(relpSrv_t *pThis, char *cert);
 relpRetVal relpSrvSetTlsConfigCmd(relpSrv_t *pThis, char *cfgcmd);
 relpRetVal relpSrvSetCACert(relpSrv_t *pThis, char *cert);
+relpRetVal relpSrvSetPrivKey(relpSrv_t *pThis, char *cert);
 relpRetVal relpSrvSetAuthMode(relpSrv_t *pThis, char *mode);
 relpRetVal relpSrvAddPermittedPeer(relpSrv_t *pThis, char *peer);
 relpRetVal relpSrvSetMaxDataSize(relpSrv_t *pThis, size_t maxSize);

--- a/src/librelp.h
+++ b/src/librelp.h
@@ -233,7 +233,8 @@ void relpSrvSetKeepAlive(relpSrv_t *pThis, const int bEnabled, const int iKeepAl
 relpRetVal relpSrvSetGnuTLSPriString(relpSrv_t *pThis, char *pristr);
 relpRetVal relpSrvSetCACert(relpSrv_t *pThis, char *cert);
 relpRetVal relpSrvSetOwnCert(relpSrv_t *pThis, char *cert);
-relpRetVal relpSrvSetPrivKey(relpSrv_t *pThis, char *cert);
+relpRetVal relpSrvSetTlsConfigCmd(relpSrv_t *pThis, char *cfgcmd);
+relpRetVal relpSrvSetCACert(relpSrv_t *pThis, char *cert);
 relpRetVal relpSrvSetAuthMode(relpSrv_t *pThis, char *mode);
 relpRetVal relpSrvAddPermittedPeer(relpSrv_t *pThis, char *peer);
 relpRetVal relpSrvSetMaxDataSize(relpSrv_t *pThis, size_t maxSize);
@@ -252,6 +253,7 @@ relpRetVal relpCltSetGnuTLSPriString(relpClt_t *pThis, char *pristr);
 relpRetVal relpCltSetCACert(relpClt_t *pThis, char *file);
 relpRetVal relpCltSetOwnCert(relpClt_t *pThis, char *file);
 relpRetVal relpCltSetPrivKey(relpClt_t *pThis, char *file);
+relpRetVal relpCltSetTlsConfigCmd(relpClt_t *pThis, char *cfgcmd);
 relpRetVal relpCltSetAuthMode(relpClt_t *pThis, char *mode);
 relpRetVal relpCltAddPermittedPeer(relpClt_t *pThis, char *peer);
 relpRetVal relpCltSetUsrPtr(relpClt_t *pThis, void *pUsr);

--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -66,6 +66,7 @@ relpCltConstruct(relpClt_t **ppThis, relpEngine_t *pEngine)
 	pThis->caCertFile = NULL;
 	pThis->ownCertFile = NULL;
 	pThis->privKey = NULL;
+	pThis->tlsConfigCmd = NULL;
 	pThis->permittedPeers.nmemb = 0;
 
 	*ppThis = pThis;
@@ -95,6 +96,7 @@ relpCltDestruct(relpClt_t **ppThis)
 	free(pThis->caCertFile);
 	free(pThis->ownCertFile);
 	free(pThis->privKey);
+	free(pThis->tlsConfigCmd);
 	for(i = 0 ; i < pThis->permittedPeers.nmemb ; ++i)
 		free(pThis->permittedPeers.name[i]);
 
@@ -130,6 +132,7 @@ relpCltConnect(relpClt_t *pThis, int protFamily, unsigned char *port, unsigned c
 		CHKRet(relpSessSetCACert(pThis->pSess, pThis->caCertFile));
 		CHKRet(relpSessSetOwnCert(pThis->pSess, pThis->ownCertFile));
 		CHKRet(relpSessSetPrivKey(pThis->pSess, pThis->privKey));
+		CHKRet(relpSessSetTlsConfigCmd(pThis->pSess, pThis->tlsConfigCmd));
 		CHKRet(relpSessSetAuthMode(pThis->pSess, pThis->authmode));
 		CHKRet(relpSessSetPermittedPeers(pThis->pSess, &pThis->permittedPeers));
 	}
@@ -335,6 +338,22 @@ relpCltSetPrivKey(relpClt_t *pThis, char *file)
 	}
 finalize_it:
 	LEAVE_RELPFUNC;
+}
+relpRetVal
+relpCltSetTlsConfigCmd(relpClt_t *pThis, char *cfgcmd)
+{
+	ENTER_RELPFUNC;
+	RELPOBJ_assert(pThis, Clt);
+	free(pThis->tlsConfigCmd);
+	if(cfgcmd == NULL) {
+		pThis->tlsConfigCmd = NULL;
+	} else {
+		if((pThis->tlsConfigCmd = strdup(cfgcmd)) == NULL)
+			ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
+	}
+finalize_it:
+	LEAVE_RELPFUNC;
+
 }
 /* Enable TLS mode. */
 relpRetVal

--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -129,10 +129,10 @@ relpCltConnect(relpClt_t *pThis, int protFamily, unsigned char *port, unsigned c
 			CHKRet(relpSessEnableTLSZip(pThis->pSess));
 		}
 		CHKRet(relpSessSetGnuTLSPriString(pThis->pSess, pThis->pristring));
+		CHKRet(relpSessSetTlsConfigCmd(pThis->pSess, pThis->tlsConfigCmd));
 		CHKRet(relpSessSetCACert(pThis->pSess, pThis->caCertFile));
 		CHKRet(relpSessSetOwnCert(pThis->pSess, pThis->ownCertFile));
 		CHKRet(relpSessSetPrivKey(pThis->pSess, pThis->privKey));
-		CHKRet(relpSessSetTlsConfigCmd(pThis->pSess, pThis->tlsConfigCmd));
 		CHKRet(relpSessSetAuthMode(pThis->pSess, pThis->authmode));
 		CHKRet(relpSessSetPermittedPeers(pThis->pSess, &pThis->permittedPeers));
 	}

--- a/src/relpclt.h
+++ b/src/relpclt.h
@@ -49,6 +49,7 @@ struct relpClt_s {
 	char *caCertFile;
 	char *ownCertFile;
 	char *privKey;
+	char *tlsConfigCmd;	/**< optional configuration command property for TLS libs **/
 	relpPermittedPeers_t permittedPeers;
 	int protFamily;		/**< protocol family to connect over (IPv4, v6, ...) */
 	unsigned char *port;	/**< server port to connect to */

--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -876,10 +876,10 @@ relpSessConnect(relpSess_t *pThis, int protFamily, unsigned char *port, unsigned
 			CHKRet(relpTcpEnableTLSZip(pThis->pTcp));
 		}
 		CHKRet(relpTcpSetGnuTLSPriString(pThis->pTcp, pThis->pristring));
+		CHKRet(relpTcpSetTlsConfigCmd(pThis->pTcp, pThis->tlsConfigCmd));
 		CHKRet(relpTcpSetCACert(pThis->pTcp, pThis->caCertFile));
 		CHKRet(relpTcpSetOwnCert(pThis->pTcp, pThis->ownCertFile));
 		CHKRet(relpTcpSetPrivKey(pThis->pTcp, pThis->privKeyFile));
-		CHKRet(relpTcpSetTlsConfigCmd(pThis->pTcp, pThis->tlsConfigCmd));
 		CHKRet(relpTcpSetAuthMode(pThis->pTcp, pThis->authmode));
 		CHKRet(relpTcpSetPermittedPeers(pThis->pTcp, &pThis->permittedPeers));
 	}

--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -136,6 +136,7 @@ relpSessConstruct(relpSess_t **ppThis, relpEngine_t *pEngine, int connType, void
 	pThis->caCertFile = NULL;
 	pThis->ownCertFile = NULL;
 	pThis->privKeyFile = NULL;
+	pThis->tlsConfigCmd = NULL;
 	pThis->permittedPeers.nmemb = 0;
 
 	CHKRet(relpSendqConstruct(&pThis->pSendq, pThis->pEngine));
@@ -206,6 +207,7 @@ relpSessDestruct(relpSess_t **ppThis)
 	free(pThis->caCertFile);
 	free(pThis->ownCertFile);
 	free(pThis->privKeyFile);
+	free(pThis->tlsConfigCmd);
 	relpSessFreePermittedPeers(pThis);
 
 	pthread_mutex_destroy(&pThis->mutSend);
@@ -877,6 +879,7 @@ relpSessConnect(relpSess_t *pThis, int protFamily, unsigned char *port, unsigned
 		CHKRet(relpTcpSetCACert(pThis->pTcp, pThis->caCertFile));
 		CHKRet(relpTcpSetOwnCert(pThis->pTcp, pThis->ownCertFile));
 		CHKRet(relpTcpSetPrivKey(pThis->pTcp, pThis->privKeyFile));
+		CHKRet(relpTcpSetTlsConfigCmd(pThis->pTcp, pThis->tlsConfigCmd));
 		CHKRet(relpTcpSetAuthMode(pThis->pTcp, pThis->authmode));
 		CHKRet(relpTcpSetPermittedPeers(pThis->pTcp, &pThis->permittedPeers));
 	}
@@ -1146,6 +1149,24 @@ relpSessSetPrivKey(relpSess_t *pThis, char *cert)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
+
+relpRetVal
+relpSessSetTlsConfigCmd(relpSess_t *pThis, char *cfgcmd)
+{
+	ENTER_RELPFUNC;
+	RELPOBJ_assert(pThis, Sess);
+
+	free(pThis->tlsConfigCmd);
+	if(cfgcmd == NULL) {
+		pThis->tlsConfigCmd = NULL;
+	} else {
+		if((pThis->tlsConfigCmd = strdup(cfgcmd)) == NULL)
+			ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
+	}
+finalize_it:
+	LEAVE_RELPFUNC;
+}
+
 
 /* set the protocol version to be used by this session
  * rgerhards, 2008-03-25

--- a/src/relpsess.h
+++ b/src/relpsess.h
@@ -91,6 +91,7 @@ struct relpSess_s {
 	char *caCertFile;
 	char *ownCertFile;
 	char *privKeyFile;
+	char *tlsConfigCmd;	/**< optional configuration command property for TLS libs **/
 	relpAuthMode_t authmode;
 	relpPermittedPeers_t permittedPeers;
 
@@ -157,6 +158,7 @@ relpRetVal relpSessSetGnuTLSPriString(relpSess_t *pThis, char *pristr);
 relpRetVal relpSessSetCACert(relpSess_t *pThis, char *cert);
 relpRetVal relpSessSetOwnCert(relpSess_t *pThis, char *cert);
 relpRetVal relpSessSetPrivKey(relpSess_t *pThis, char *cert);
+relpRetVal relpSessSetTlsConfigCmd(relpSess_t *pThis, char *cfgcmd);
 relpRetVal relpSessConstructOffers(relpSess_t *pThis, relpOffers_t **ppOffers);
 relpRetVal relpSessSetPermittedPeers(relpSess_t *pThis, relpPermittedPeers_t *pPeers);
 relpRetVal relpSessSetUsrPtr(relpSess_t *pThis, void *pUsr);

--- a/src/relpsrv.c
+++ b/src/relpsrv.c
@@ -414,11 +414,11 @@ relpSrvRun(relpSrv_t *pThis)
 		}
 		relpTcpSetDHBits(pTcp, pThis->dhBits);
 		CHKRet(relpTcpSetGnuTLSPriString(pTcp, pThis->pristring));
+		CHKRet(relpTcpSetTlsConfigCmd(pTcp, pThis->tlsConfigCmd));
 		CHKRet(relpTcpSetAuthMode(pTcp, pThis->authmode));
 		CHKRet(relpTcpSetCACert(pTcp, pThis->caCertFile));
 		CHKRet(relpTcpSetOwnCert(pTcp, pThis->ownCertFile));
 		CHKRet(relpTcpSetPrivKey(pTcp, pThis->privKey));
-		CHKRet(relpTcpSetTlsConfigCmd(pTcp, pThis->tlsConfigCmd));
 		CHKRet(relpTcpSetPermittedPeers(pTcp, &(pThis->permittedPeers)));
 	}
 	CHKRet(relpTcpLstnInit(pTcp, (pThis->pLstnPort == NULL) ?

--- a/src/relpsrv.c
+++ b/src/relpsrv.c
@@ -68,6 +68,7 @@ relpSrvConstruct(relpSrv_t **ppThis, relpEngine_t *pEngine)
 	pThis->caCertFile = NULL;
 	pThis->ownCertFile = NULL;
 	pThis->privKey = NULL;
+	pThis->tlsConfigCmd = NULL;
 	pThis->permittedPeers.nmemb = 0;
 	pThis->maxDataSize = RELP_DFLT_MAX_DATA_SIZE;
 	pThis->oversizeMode = RELP_DFLT_OVERSIZE_MODE;
@@ -101,6 +102,7 @@ relpSrvDestruct(relpSrv_t **ppThis)
 	free(pThis->caCertFile);
 	free(pThis->ownCertFile);
 	free(pThis->privKey);
+	free(pThis->tlsConfigCmd);
 	for(i = 0 ; i < pThis->permittedPeers.nmemb ; ++i)
 		free(pThis->permittedPeers.name[i]);
 	/* done with de-init work, now free srv object itself */
@@ -326,6 +328,21 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
+relpRetVal
+relpSrvSetTlsConfigCmd(relpSrv_t *pThis, char *cfgcmd)
+{
+	ENTER_RELPFUNC;
+	RELPOBJ_assert(pThis, Srv);
+	free(pThis->tlsConfigCmd);
+	if(cfgcmd == NULL) {
+		pThis->tlsConfigCmd = NULL;
+	} else {
+		if((pThis->tlsConfigCmd = strdup(cfgcmd)) == NULL)
+			ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
+	}
+finalize_it:
+	LEAVE_RELPFUNC;
+}
 void
 relpSrvSetDHBits(relpSrv_t *pThis, int bits)
 {
@@ -401,6 +418,7 @@ relpSrvRun(relpSrv_t *pThis)
 		CHKRet(relpTcpSetCACert(pTcp, pThis->caCertFile));
 		CHKRet(relpTcpSetOwnCert(pTcp, pThis->ownCertFile));
 		CHKRet(relpTcpSetPrivKey(pTcp, pThis->privKey));
+		CHKRet(relpTcpSetTlsConfigCmd(pTcp, pThis->tlsConfigCmd));
 		CHKRet(relpTcpSetPermittedPeers(pTcp, &(pThis->permittedPeers)));
 	}
 	CHKRet(relpTcpLstnInit(pTcp, (pThis->pLstnPort == NULL) ?

--- a/src/relpsrv.h
+++ b/src/relpsrv.h
@@ -60,6 +60,7 @@ struct relpSrv_s {
 	char *caCertFile;
 	char *ownCertFile;
 	char *privKey;
+	char *tlsConfigCmd;	/**< optional configuration command property for TLS libs **/
 	relpAuthMode_t authmode;
 	relpPermittedPeers_t permittedPeers;
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1096,7 +1096,6 @@ relpTcpSetTlsConfigCmd(relpTcp_t *const pThis, char *cfgcmd)
 {
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Tcp);
-
 	free(pThis->tlsConfigCmd);
 	if(cfgcmd == NULL) {
 		pThis->tlsConfigCmd = NULL;
@@ -1567,22 +1566,23 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
-static relpRetVal LIBRELP_ATTR_NONNULL()
+static relpRetVal
 relpTcpSetSslConfCmd_ossl(relpTcp_t *const pThis, char *tlsConfigCmd)
 {
 	ENTER_RELPFUNC;
 
 	/* Skip function if function is NULL tlsConfigCmd */
 	if (tlsConfigCmd == NULL) {
+		pThis->pEngine->dbgprint("relpTcpSetSslConfCmd_ossl: tlsConfigCmd is NULL\n");
 		LEAVE_RELPFUNC;
 	} else {
 		pThis->pEngine->dbgprint("relpTcpSetSslConfCmd_ossl: set to '%s'\n", tlsConfigCmd);
+		char errmsg[1424];
 #if OPENSSL_VERSION_NUMBER >= 0x10020000L
 		char *pCurrentPos;
 		char *pNextPos;
 		char *pszCmd;
 		char *pszValue;
-		char errmsg[1424];
 		int iConfErr;
 
 		/* Set working pointer */
@@ -1697,9 +1697,6 @@ relpTcpAcceptConnReqInitTLS_ossl(relpTcp_t *const pThis, relpSrv_t *const pSrv)
 
 	/*set Server state */
 	pThis->sslState = osslServer;
-
-	/* Set TLS Options if configured */
-	CHKRet(relpTcpSetSslConfCmd_ossl(pThis, pThis->tlsConfigCmd));
 
 	/* Create BIO from ptcp socket! */
 	client = BIO_new_socket(pThis->sock, BIO_CLOSE /*BIO_NOCLOSE*/);
@@ -1839,6 +1836,10 @@ relpTcpLstnInitTLS_ossl(relpTcp_t *const pThis)
 	if(!called_openssl_global_init) {
 		CHKRet(relpTcpInitTLS(pThis));
 	}
+
+	/* Set TLS Options if configured */
+	CHKRet(relpTcpSetSslConfCmd_ossl(pThis, pThis->tlsConfigCmd));
+
 	pThis->pEngine->dbgprint("relpTcpLstnInitTLS openssl init done \n");
 
 finalize_it:

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -639,6 +639,7 @@ relpTcpConstruct(relpTcp_t **ppThis, relpEngine_t *const pEngine,
 	pThis->caCertFile = NULL;
 	pThis->ownCertFile = NULL;
 	pThis->privKeyFile = NULL;
+	pThis->tlsConfigCmd = NULL;
 	pThis->pUsr = NULL;
 	pThis->permittedPeers.nmemb = 0;
 	pThis->permittedPeers.peer = NULL;
@@ -769,6 +770,7 @@ relpTcpDestruct(relpTcp_t **ppThis)
 	free(pThis->caCertFile);
 	free(pThis->ownCertFile);
 	free(pThis->privKeyFile);
+	free(pThis->tlsConfigCmd);
 
 	/* done with de-init work, now free tcp object itself */
 	free(pThis);
@@ -1089,6 +1091,22 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
+relpRetVal
+relpTcpSetTlsConfigCmd(relpTcp_t *const pThis, char *cfgcmd)
+{
+	ENTER_RELPFUNC;
+	RELPOBJ_assert(pThis, Tcp);
+
+	free(pThis->tlsConfigCmd);
+	if(cfgcmd == NULL) {
+		pThis->tlsConfigCmd = NULL;
+	} else {
+		if((pThis->tlsConfigCmd = strdup(cfgcmd)) == NULL)
+			ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
+	}
+finalize_it:
+	LEAVE_RELPFUNC;
+}
 
 /* Enable TLS mode. */
 relpRetVal
@@ -1550,6 +1568,102 @@ finalize_it:
 }
 
 static relpRetVal LIBRELP_ATTR_NONNULL()
+relpTcpSetSslConfCmd_ossl(relpTcp_t *const pThis, char *tlsConfigCmd)
+{
+	ENTER_RELPFUNC;
+
+	/* Skip function if function is NULL tlsConfigCmd */
+	if (tlsConfigCmd == NULL) {
+		LEAVE_RELPFUNC;
+	} else {
+		pThis->pEngine->dbgprint("relpTcpSetSslConfCmd_ossl: set to '%s'\n", tlsConfigCmd);
+#if OPENSSL_VERSION_NUMBER >= 0x10020000L
+		char *pCurrentPos;
+		char *pNextPos;
+		char *pszCmd;
+		char *pszValue;
+		char errmsg[1424];
+		int iConfErr;
+
+		/* Set working pointer */
+		pCurrentPos = tlsConfigCmd;
+		if (pCurrentPos != NULL && strlen(pCurrentPos) > 0) {
+			// Create CTX Config Helper
+			SSL_CONF_CTX *cctx;
+			cctx = SSL_CONF_CTX_new();
+			if (pThis->sslState == osslServer) {
+				SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_SERVER);
+			} else {
+				SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
+			}
+			SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE);
+			SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_SHOW_ERRORS);
+			SSL_CONF_CTX_set_ssl_ctx(cctx, ctx);
+
+			do
+			{
+				pNextPos = index(pCurrentPos, '=');
+				if (pNextPos != NULL) {
+					while (	*pCurrentPos != '\0' &&
+						(*pCurrentPos == ' ' || *pCurrentPos == '\t') )
+						pCurrentPos++;
+					pszCmd = strndup(pCurrentPos, pNextPos-pCurrentPos);
+					pCurrentPos = pNextPos+1;
+					pNextPos = index(pCurrentPos, '\n');
+					pszValue = (pNextPos == NULL ?
+							strdup(pCurrentPos) :
+							strndup(pCurrentPos, pNextPos - pCurrentPos));
+					pCurrentPos = (pNextPos == NULL ? NULL : pNextPos+1);
+
+					/* Add SSL Conf Command */
+					iConfErr = SSL_CONF_cmd(cctx, pszCmd, pszValue);
+					if (iConfErr > 0) {
+						pThis->pEngine->dbgprint("relpTcpSetSslConfCmd_ossl: "
+							"Successfully added Command '%s':'%s'\n",
+							pszCmd, pszValue);
+					}
+					else {
+						snprintf(errmsg, sizeof(errmsg),
+							"Failed to added Command: %s:'%s' "
+							"in relpTcpSetSslConfCmd_ossl with error '%d'",
+							pszCmd, pszValue, iConfErr);
+						callOnErr(pThis, errmsg, RELP_RET_ERR_TLS);
+					}
+
+					free(pszCmd);
+					free(pszValue);
+				} else {
+					/* Abort further parsing */
+					pCurrentPos = NULL;
+				}
+			}
+			while (pCurrentPos != NULL);
+
+			/* Finalize SSL Conf */
+			iConfErr = SSL_CONF_CTX_finish(cctx);
+			if (!iConfErr) {
+				snprintf(errmsg, sizeof(errmsg),
+					"Failed setting openssl command parameters: %s"
+					"Open ssl error info may follow in next messages",
+					tlsConfigCmd);
+				callOnErr(pThis, errmsg, RELP_RET_ERR_TLS);
+				relpTcpLastSSLErrorMsg(0, pThis, "relpTcpSetSslConfCmd_ossl");
+			}
+		}
+#else
+		snprintf(errmsg, sizeof(errmsg),
+			"Warning: OpenSSL Version too old to set tlsConfigCmd ('%s')"
+			"by SSL_CONF_cmd API.",
+			tlsConfigCmd);
+		callOnErr(pThis, errmsg, RELP_RET_ERR_TLS);
+#endif
+	}
+
+finalize_it:
+	LEAVE_RELPFUNC;
+}
+
+static relpRetVal LIBRELP_ATTR_NONNULL()
 relpTcpAcceptConnReqInitTLS_ossl(relpTcp_t *const pThis, relpSrv_t *const pSrv)
 {
 	BIO *client = NULL;
@@ -1581,6 +1695,12 @@ relpTcpAcceptConnReqInitTLS_ossl(relpTcp_t *const pThis, relpSrv_t *const pSrv)
 		SSL_set_verify(pThis->ssl, SSL_VERIFY_NONE, verify_callback);
 	}
 
+	/*set Server state */
+	pThis->sslState = osslServer;
+
+	/* Set TLS Options if configured */
+	CHKRet(relpTcpSetSslConfCmd_ossl(pThis, pThis->tlsConfigCmd));
+
 	/* Create BIO from ptcp socket! */
 	client = BIO_new_socket(pThis->sock, BIO_CLOSE /*BIO_NOCLOSE*/);
 	pThis->pEngine->dbgprint("relpTcpAcceptConnReqInitTLS_ossl: Init client BIO[%p] done\n", (void *)client);
@@ -1596,7 +1716,6 @@ BIO_set_nbio( client, 1 );
 	SSL_set_accept_state(pThis->ssl); /* sets ssl to work in server mode. */
 
 	pThis->bTLSActive = 1;
-	pThis->sslState = osslServer; /*set Server state */
 
 	/* We now do the handshake */
 	CHKRet(relpTcpRtryHandshake(pThis));
@@ -1645,6 +1764,12 @@ relpTcpConnectTLSInit_ossl(relpTcp_t *const pThis)
 		CHKRet(relpTcpInitTLS(pThis));
 	}
 
+	/*set client state */
+	pThis->sslState = osslClient;
+
+	/* Set TLS Options if configured */
+	CHKRet(relpTcpSetSslConfCmd_ossl(pThis, pThis->tlsConfigCmd));
+
 	/* Create BIO from ptcp socket! */
 	conn = BIO_new_socket(pThis->sock, BIO_CLOSE /*BIO_NOCLOSE*/);
 	pThis->pEngine->dbgprint("relpTcpConnectTLSInit: Init conn BIO[%p] done\n", (void *)conn);
@@ -1660,7 +1785,6 @@ BIO_set_nbio( conn, 1 );
 	pThis->pEngine->dbgprint("relpTcpConnectTLSInit: TLS Mode\n");
 	if(!(pThis->ssl = SSL_new(ctx))) {
 		relpTcpLastSSLErrorMsg(0, pThis, "relpTcpConnectTLSInit");
-/*		errmsg.LogError(0, RS_RET_NO_ERRCODE, "Error creating an SSL context"); */
 		ABORT_FINALIZE(RELP_RET_IO_ERR);
 	}
 
@@ -1676,7 +1800,6 @@ BIO_set_nbio( conn, 1 );
 
 	SSL_set_bio(pThis->ssl, conn, conn);
 	SSL_set_connect_state(pThis->ssl); /*sets ssl to work in client mode.*/
-	pThis->sslState = osslClient; /*set client state */
 
 	/* Perform the TLS handshake */
 	pThis->pEngine->dbgprint("relpTcpConnectTLSInit: try handshake for [%p]\n", (void *)pThis);

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -131,6 +131,7 @@ typedef struct relpTcp_s {
 	char *caCertFile;
 	char *ownCertFile;
 	char *privKeyFile;
+	char *tlsConfigCmd;	/**< optional configuration command property for TLS libs **/
 	#ifdef ENABLE_TLS
 	gnutls_session_t session;
 	gnutls_dh_params_t dh_params; /**< server DH parameters for anon mode */
@@ -171,6 +172,7 @@ relpRetVal relpTcpSetGnuTLSPriString(relpTcp_t *pThis, char *pristr);
 relpRetVal relpTcpSetCACert(relpTcp_t *pThis, char *cert);
 relpRetVal relpTcpSetOwnCert(relpTcp_t *pThis, char *cert);
 relpRetVal relpTcpSetPrivKey(relpTcp_t *pThis, char *cert);
+relpRetVal relpTcpSetTlsConfigCmd(relpTcp_t *pThis, char *cfgcmd);
 relpRetVal relpTcpSetPermittedPeers(relpTcp_t *pThis, relpPermittedPeers_t *pPeers);
 relpRetVal LIBRELP_ATTR_NONNULL() relpTcpRtryHandshake(relpTcp_t *pThis);
 relpRetVal relpTcpSetUsrPtr(relpTcp_t *pThis, void *pUsr);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,6 +23,7 @@ TLS_TESTS=  \
 	tls-basic-certvalid.sh \
 	tls-basic-fingerprint.sh \
 	tls-basic-wildcard.sh \
+	tls-basic-tlscommand.sh \
 	tls-receiver-abort.sh \
 	tls-missing-param-sender.sh \
 	tls-missing-param-receiver.sh

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -107,19 +107,34 @@ set +x; set +v
 # $1 is the value to check for
 # $2 (optinal) is the file to check
 check_output() {
+	if [ "$1" == "--check-only" ]; then
+		check_only="yes"
+		shift
+	else
+		check_only="no"
+	fi
+
 	EXPECTED="$1"
 	if [ "$2" == "" ] ; then
 		FILE_TO_CHECK="$OUTFILE"
 	else
 		FILE_TO_CHECK="$2"
 	fi
+
 	grep $3 "$EXPECTED" $FILE_TO_CHECK > /dev/null
 	if [ $? -ne 0 ]; then
+		if [ "$check_only" == "yes" ]; then
+			printf 'check_output did not yet succeed (check_only set)\n'
+			return 1
+		fi
 		printf "\nFAIL: expected message not found. Expected:\n"
 		printf "%s\n" "$EXPECTED"
 		printf "\n$FILE_TO_CHECK actually is:\n"
 		cat $FILE_TO_CHECK
 		exit 1
+	fi
+	if [ "$check_only" == "yes" ]; then
+		return 0
 	fi
 }
 

--- a/tests/tls-basic-tlscommand.sh
+++ b/tests/tls-basic-tlscommand.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+. ${srcdir:=$(pwd)}/test-framework.sh
+
+function actual_test() {
+	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
+		-y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem \
+		-P 'testbench.rsyslog.com' \
+		--errorfile error.out.log \
+		-c "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2"
+
+	echo 'Send Message...'
+	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" \
+		-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
+		-z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' \
+		-c "Protocol=-ALL,TLSv1.2" \
+		--errorfile error.out.log \
+		$OPT_VERBOSE
+
+	stop_receiver
+	
+	# Test only supported for OpenSSL
+	if [ "$TEST_TLS_LIB" == "openssl" ]; then
+		check_output --check-only "OpenSSL Version too old" error.out.log
+		ret=$?
+		if [ $ret == 0 ]; then
+			echo "SKIP: OpenSSL Version too old"
+			exit 77
+		else
+			if test -f "error.out.log"; then
+				check_output "error opening connection to remote peer" error.out.log
+			else
+				echo "SKIP: error.out.log was not created"
+				exit 77
+			fi
+		
+		fi
+	fi
+}
+
+do_tls_subtests
+terminate
+


### PR DESCRIPTION
Add two API calls to set SSL_CONF_cmd properties:
- relpCltSetTlsConfigCmd
- relpSrvSetTlsConfigCmd

cfgcmd is used to pass configuration commands to openssl.
The format is one command per line, command and value separated by equal sign (=).
See this sample:
"command=value
secondcommand=value"

