### PR TITLE
report io errors for plain tcp connections

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -3207,8 +3207,15 @@ relpTcpSend(relpTcp_t *const pThis, relpOctet_t *const pBuf, ssize_t *const pLen
 					/* this is fine, just retry... */
 					written = 0;
 					break;
-				default:
+				default: {
+					char msgbuf[900];
+					char errStr[800];
+					_relpEngine_strerror_r(errno, errStr, sizeof(errStr));
+					snprintf(msgbuf, sizeof(msgbuf), "error sending relp: %s", errStr);
+					msgbuf[sizeof(msgbuf)-1] = '\0';
+					callOnErr(pThis, msgbuf, RELP_RET_IO_ERR);
 					ABORT_FINALIZE(RELP_RET_IO_ERR);
+					}
 					break;
 			}
 		}

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -2005,6 +2005,7 @@ relpTcpAcceptConnReq(relpTcp_t **ppThis, const int sock, relpSrv_t *const pSrv)
 
 	/* construct our object so that we can use it... */
 	CHKRet(relpTcpConstruct(&pThis, pEngine, RELP_SRV_CONN, pSrv));
+	pThis->pUsr = pSrv->pUsr;
 
 	if(pSrv->bKeepAlive)
 		EnableKeepAlive(pThis, pSrv, iNewSock);


### PR DESCRIPTION
this already happens with TLS, but not with plain tcp. Error messages
are a useful troubleshooting tool.