### PR TITLE
LibreSSL has no support for @SECLEVEL and SSL_CONF_CTX_set_flags().

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1200,7 +1200,8 @@ relpTcpTLSSetPrio_ossl(relpTcp_t *const pThis)
 	/* Compute priority string (in simple cases where the user does not care...) */
 	if(pThis->pristring == NULL) {
 		if (pThis->authmode == eRelpAuthMode_None) {
-			#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+			#if OPENSSL_VERSION_NUMBER >= 0x10100000L \
+				&& !defined(LIBRESSL_VERSION_NUMBER)
 			 /* NOTE: do never use: +eNULL, it DISABLES encryption! */
 			strncpy(pristringBuf, "ALL:+COMPLEMENTOFDEFAULT:+ADH:+ECDH:+aNULL@SECLEVEL=0",
 				sizeof(pristringBuf));
@@ -1578,7 +1579,7 @@ relpTcpSetSslConfCmd_ossl(relpTcp_t *const pThis, char *tlsConfigCmd)
 	} else {
 		pThis->pEngine->dbgprint("relpTcpSetSslConfCmd_ossl: set to '%s'\n", tlsConfigCmd);
 		char errmsg[1424];
-#if OPENSSL_VERSION_NUMBER >= 0x10020000L
+#if OPENSSL_VERSION_NUMBER >= 0x10020000L && !defined(LIBRESSL_VERSION_NUMBER)
 		char *pCurrentPos;
 		char *pNextPos;
 		char *pszCmd;


### PR DESCRIPTION
With this I can build librelp on OpenBSD where LibreSSL is the default.