### PR TITLE
replsess: fix double free of sendbuf in some cases.

### DIFF
--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -329,10 +329,15 @@ finalize_it:
 			callOnErr(pThis, "io error, session broken", RELP_RET_SESSION_BROKEN);
 			pThis->pEngine->dbgprint("relp session %p is broken, io error\n", (void*)pThis);
 			pThis->sessState = eRelpSessState_BROKEN;
-			}
+		} else {
+			/*	alorbach, 2020-04-08:
+			*		Only free sendbuf if error is not RELP_RET_IO_ERR!
+			*		otherwise the buffer is double freed in relpSendbufDestruct() (sendbuf.c)
+			*/
+			if(pSendbuf != NULL)
+				relpSendbufDestruct(&pSendbuf);
+		}
 
-		if(pSendbuf != NULL)
-			relpSendbufDestruct(&pSendbuf);
 	}
 
 	LEAVE_RELPFUNC;


### PR DESCRIPTION
In iRet handler of relpSessSendResponse, the sendbuf
was freed if iRet returned a failure.

However if error RELP_RET_IO_ERR happened in relpSendqAddBuf,
sendbuf was already assigned to relpSendqe_t. As a result
sendbuf was double freed in relpSendqDestruct.

see also
https://github.com/rsyslog/rsyslog/issues/4184
https://github.com/rsyslog/rsyslog/issues/4005

closes https://github.com/rsyslog/librelp/issues/183