### PR TITLE
build system: do not export librelp internal driver APIs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,6 @@ librelp_la_CPPFLAGS = $(AM_CLFAGS) $(PTHREADS_CFLAGS) $(GNUTLS_CFLAGS) $(OPENSSL
 librelp_la_LIBADD = $(rt_libs) $(GNUTLS_LIBS) $(OPENSSL_LIBS)
 # info on version-info:
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-librelp_la_LDFLAGS = -version-info 5:0:5 -export-symbols-regex '^relp'
+librelp_la_LDFLAGS = -version-info 5:0:5 -export-symbols-regex '^relp[^_]*$$'
 
 include_HEADERS = librelp.h


### PR DESCRIPTION
Librelp exported some functions related to the internal driver API. This
was not desired and is fixed with this commit. We assume, and require
from now on, that driver functions contain an underscore "_" in their
name. This is how they are already named.

closes https://github.com/rsyslog/librelp/issues/179