### PR TITLE
fix memory leak on session break.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,7 +13,9 @@ chkseq_SOURCES=chkseq.c
 have_tlslib_SOURCES=have_tlslib.c
 
 VALGRIND_TESTS= \
-	duplicate-receiver-vg.sh
+	duplicate-receiver-vg.sh \
+	basic-sessionbreak-vg.sh
+
 
 # TLS tests that work both with gnutls and openssl
 TLS_TESTS=  \

--- a/tests/basic-sessionbreak-vg.sh
+++ b/tests/basic-sessionbreak-vg.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+. ${srcdir:=$(pwd)}/test-framework.sh
+if [ "$VALGRIND" == "NO" ] ; then
+   echo "valgrind tests are not permitted by environment config"
+   exit 77
+fi
+if [ $(uname) = "SunOS" ] ; then
+   echo "This test currently does not work on all flavors of Solaris."
+   exit 77
+fi
+if [ $(uname) = "FreeBSD" ] ; then
+   echo "This test currently does not work on FreeBSD."
+   exit 77	
+fi
+export NUMMESSAGES=100000
+export NUMLOOPS=2
+
+#export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
+export valgrind="valgrind --malloc-fill=ff --free-fill=fe --leak-check=full --log-fd=1 --error-exitcode=10 --gen-suppressions=all"
+	
+startup_receiver_valgrind --no-exit-on-error -e error.out.log --outfile $OUTFILE
+
+echo 'Send Message(s)...'
+for i in $(seq 1 $NUMLOOPS); do 
+        # How many times tcpflood runs in each threads
+	libtool --mode=execute ./send --no-exit-on-error -t 127.0.0.1 -p $TESTPORT -m "testmessage" -n $NUMMESSAGES $OPT_VERBOSE &
+	send_pid=$!
+
+	echo "started send instance $i (PID $send_pid)"
+
+	# Give it time to actually connect
+	sleep 1;
+
+	kill -9 $send_pid # >/dev/null 2>&1;
+	echo "killed send instance $i (PID $send_pid)"
+done;
+
+stop_receiver
+
+if [ "$RECEIVE_EXIT" -eq "10" ]; then
+	cleanup
+	printf 'valgrind run FAILED with exceptions\n'
+	printf "%s %s FAIL\n" "$(date +%H:%M:%S)" "$0"
+	exit 1
+fi
+
+#	check_output "testmessage"
+
+terminate

--- a/tests/send.c
+++ b/tests/send.c
@@ -242,6 +242,7 @@ int main(int argc, char *argv[]) {
 	int verbose = 0;
 	int protFamily = 2; /* IPv4=2, IPv6=10 */
 	int bEnableTLS = 0;
+	int no_exit_on_err = 0;
 	char *caCertFile = NULL;
 	char *myCertFile = NULL;
 	char *myPrivKeyFile = NULL;
@@ -276,6 +277,7 @@ int main(int argc, char *argv[]) {
 		{"kill-signal", required_argument, 0, KILL_SIGNAL},
 		{"kill-pid", required_argument, 0, KILL_PID},
 		{"connect-retries", required_argument, 0, CONNECT_RETRIES},
+		{"no-exit-on-error", no_argument, 0, 'N'},
 		{0, 0, 0, 0}
 	};
 
@@ -345,6 +347,9 @@ int main(int argc, char *argv[]) {
 		case 'z':
 			myPrivKeyFile = optarg;
 			break;
+		case 'N':
+			no_exit_on_err = 1;
+			break;
 		case KILL_ON_MSG:
 			kill_on_msg = atoi(optarg);
 			break;
@@ -364,7 +369,11 @@ int main(int argc, char *argv[]) {
 	}
 
 	atexit(exit_hdlr);
-	hdlr_enable(SIGPIPE, do_signal);
+	if (no_exit_on_err == 0) {
+		hdlr_enable(SIGPIPE, do_signal);
+	} else {
+		signal(SIGPIPE, SIG_IGN);
+	}
 
 	if(msgDataLen != 0 && msgDataLen < lenMsg) {
 		fprintf(stderr, "send: message is larger than configured message size!\n");

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -88,6 +88,7 @@ stop_receiver() {
 	fi
 	kill $RECEIVE_PID &> /dev/null
 	wait $RECEIVE_PID
+	export RECEIVE_EXIT=$?
 	printf 'receiver %d stopped\n' $RECEIVE_PID
 }
 


### PR DESCRIPTION
When librelp session breaks unexpected, a memory leak could happen in sendq.c
when relpSendqeConstruct was called before the session break happened.

- Also Adds a new valgrind test basic-sessionbreak-vg.sh to reproduce
  the problem. without the fix, the test will fail.

- Adjusted testbench plumbing to support session break valgrind test.