### PR TITLE
Fix FD leak when socket shutdown is one-sided

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -3070,7 +3070,6 @@ relpTcpRcv(relpTcp_t *const pThis, relpOctet_t *const pRcvBuf, ssize_t *const pL
 			*pLenBuf, pThis->sock);
 		if(lenRcvd == 0) {
 			pThis->pEngine->dbgprint((char*)"relpTcpRcv: invalidating closed socket\n");
-			pThis->sock = -1; /* socket is closed, no longer valid! */
 		}
 	}
 


### PR DESCRIPTION
AWS LB has timeouts when connection is inactive and when this happens, AWS LB shuts down socket from one-side only. When rsyslog detects one-sided shutdown, it assumes that connection is closed while it isn't. The connection is left unclosed and unclosed FD are piling up, eventually filling up FD number space.

Removing the assignment to -1 allows rsyslog to close the connection later.