### PR TITLE
openssl: Fix chained certificate files for older OpenSSL Version.

### DIFF
--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -1,23 +1,70 @@
 #!/bin/bash
 # This scripts uses an rsyslog development container to execute given
 # command inside it.
-# Note that we "abuse" the /rsyslog path a bit by placing our project
-# in there.
+# Note: command line parameters are passed as parameters to the container,
+# with the notable exception that -ti, if given as first parameter, is
+# passed to "docker run" itself but NOT the container.
+#
+# use env var DOCKER_RUN_EXTRA_OPTS to provide extra options to docker run
+# command.
+#
+# TO MODIFIY BEHAVIOUR, use
+# RSYSLOG_CONTAINER_UID, format uid:gid,
+#                   to change the users container is run under
+#                   set to "" to use the container default settings
+#                   (no local mapping)
 set -e
+if [ "$1" == "--rm" ]; then
+	optrm="--rm"
+	shift 1
+fi
+if [ "$1" == "-ti" ]; then
+	ti="-ti"
+	shift 1
+fi
+# check in case -ti was in front...
+if [ "$1" == "--rm" ]; then
+	optrm="--rm"
+	shift 1
+fi
 
 if [ "$PROJ_HOME" == "" ]; then
 	export PROJ_HOME=$(pwd)
 	echo info: PROJ_HOME not set, using $PROJ_HOME
 fi
 
-DEV_CONTAINER=$(cat $PROJ_HOME/devtools/default_dev_container)
+if [ -z "$DEV_CONTAINER" ]; then
+	DEV_CONTAINER=$(cat $PROJ_HOME/devtools/default_dev_container)
+fi
 
-printf "/rsyslog is mapped to $PROJ_HOME\n"
+printf '/rsyslog is mapped to %s \n' "$PROJ_HOME"
+printf 'using container %s\n' "$DEV_CONTAINER"
+printf 'pulling container...\n'
+printf 'user ids: %s:%s\n' $(id -u) $(id -g)
+printf 'container_uid: %s\n' ${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)}
 docker pull $DEV_CONTAINER
-docker run \
-	-u $(id -u):$(id -g) \
+docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e PROJ_CONFIGURE_OPTIONS_EXTRA \
+	-e PROJ_CONFIGURE_OPTIONS_OVERRIDE \
 	-e CC \
 	-e CFLAGS \
+	-e LDFLAGS \
+	-e LSAN_OPTIONS \
+	-e TSAN_OPTIONS \
+	-e UBSAN_OPTIONS \
+	-e CI_MAKE_OPT \
+	-e CI_MAKE_CHECK_OPT \
+	-e CI_CHECK_CMD \
+	-e CI_BUILD_URL \
+	-e CI_CODECOV_TOKEN \
+	-e CI_VALGRIND_SUPPRESSIONS \
+	-e CI_SANITIZE_BLACKLIST \
+	-e ABORT_ALL_ON_TEST_FAIL \
+	-e USE_AUTO_DEBUG \
+	-e RSYSLOG_STATSURL \
+	-e VCS_SLUG \
+	--cap-add SYS_ADMIN \
+	--cap-add SYS_PTRACE \
+	${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)} \
 	$DOCKER_RUN_EXTRA_FLAGS \
-	-v "$PROJ_HOME":/rsyslog $DEV_CONTAINER  $*
+	-v "$PROJ_HOME":/rsyslog $DEV_CONTAINER $*

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1379,18 +1379,32 @@ relpTcpInitTLS(relpTcp_t *const pThis)
 			relpTcpLastSSLErrorMsg(0, pThis, "relpTcpInitTLS");
 			ABORT_FINALIZE(RELP_RET_ERR_TLS_SETUP);
 		} else
-			pThis->pEngine->dbgprint((char*)"relpTcpInitTLS: Successfully initialized CA certificate\n");
+			pThis->pEngine->dbgprint((char*)"relpTcpInitTLS: Successfully initialized CA certificate #1\n");
 	} else {
-		// Init local System default certificate storage instead. 
+		/* Init CA from own Certificate */
+		if(	pThis->ownCertFile != NULL ) {
+			if (SSL_CTX_load_verify_locations(ctx, pThis->ownCertFile, NULL) != 1) {
+				callOnErr(pThis, (char*)"relpTcpInitTLS: Error, Certificate could not be accessed."
+						" Is the file at the right path? And do we have the permissions?\n",
+						RELP_RET_ERR_TLS_SETUP);
+				/* Output Additional OpenSSL output */
+				relpTcpLastSSLErrorMsg(0, pThis, "relpTcpInitTLS");
+				ABORT_FINALIZE(RELP_RET_ERR_TLS_SETUP);
+			} else
+				pThis->pEngine->dbgprint(
+					(char*)"relpTcpInitTLS: Successfully initialized CA Certificate #2\n");
+		}
+
+		// Init local System default certificate storage instead.
 		if (SSL_CTX_set_default_verify_paths(ctx) != 1) {
-			callOnErr(pThis, (char*)"relpTcpInitTLS: Error, CA default certificate storage could not be set.",
-					RELP_RET_ERR_TLS_SETUP);
+			callOnErr(pThis, (char*)"relpTcpInitTLS: Error, CA default certificate storage "
+					"could not be set.", RELP_RET_ERR_TLS_SETUP);
 			/* Output Additional OpenSSL output */
 			relpTcpLastSSLErrorMsg(0, pThis, "relpTcpInitTLS");
 			ABORT_FINALIZE(RELP_RET_ERR_TLS_SETUP);
 		} else
-			pThis->pEngine->dbgprint((char*)"relpTcpInitTLS: Successfully initialized default CA certificate "
-				"storage\n");
+			pThis->pEngine->dbgprint((char*)"relpTcpInitTLS: Successfully initialized default "
+					"CA certificate storage\n");
 	}
 
 	called_openssl_global_init = 1;

--- a/tests/tls-basic-certchain.sh
+++ b/tests/tls-basic-certchain.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 . ${srcdir:=$(pwd)}/test-framework.sh
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "certvalid" -x ${srcdir}/tls-certs/ossl-server-certchain.pem -y ${srcdir}/tls-certs/ossl-server-certchain.pem -z ${srcdir}/tls-certs/ossl-server-key.pem  -e error.out.log
+	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "certvalid" -y ${srcdir}/tls-certs/ossl-server-certchain.pem -z ${srcdir}/tls-certs/ossl-server-key.pem  -e error.out.log
 
 	echo 'Send Message...'
-	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -x ${srcdir}/tls-certs/ossl-client-certchain.pem -y ${srcdir}/tls-certs/ossl-client-certchain.pem -z ${srcdir}/tls-certs/ossl-client-key.pem $OPT_VERBOSE 1>>${OUTFILE} 2>&1
+	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -y ${srcdir}/tls-certs/ossl-client-certchain.pem -z ${srcdir}/tls-certs/ossl-client-key.pem $OPT_VERBOSE 1>>${OUTFILE} 2>&1
 
 	stop_receiver
 	check_output "testmessage"


### PR DESCRIPTION
For older OpenSSL Versions, we are loading the Own Certfile
(Which can be chained) into CTX Verify locations. This enables
chained certificates for older OpenSSL Versions as well

devtools: updated devcontainer.sh (based on rsyslog version)

see also: https://github.com/rsyslog/librelp/issues/195