### PR TITLE
bugfix: library did export non-API symbols

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,6 +12,7 @@ endif
 DEBUG = -g
 # Uncomment for debugging
 #CFLAGS += $(DEBUG)
+AM_CFLAGS=-fvisibility=hidden
 
 lib_LTLIBRARIES = librelp.la
 

--- a/src/relp.c
+++ b/src/relp.c
@@ -51,7 +51,7 @@
 
 /* ------------------------------ some internal functions ------------------------------ */
 
-void LIBRELP_ATTR_FORMAT(printf, 4, 5)
+void PART_OF_API LIBRELP_ATTR_FORMAT(printf, 4, 5)
 relpEngineCallOnGenericErr(relpEngine_t *pThis, const char *eobj, relpRetVal ecode, const char *fmt, ...)
 {
 	va_list ap;
@@ -247,7 +247,7 @@ relpEngineDelSess(relpEngine_t *pThis, relpEngSessLst_t *pSessLstEntry)
  * RELP function. The relp engine must only destructed after all RELP
  * operations have been finished.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineConstruct(relpEngine_t **ppThis)
 {
 	relpEngine_t *pThis;
@@ -281,7 +281,7 @@ finalize_it:
  * Terminates librelp operations, no calls are permitted after engine
  * destruction.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineDestruct(relpEngine_t **ppThis)
 {
 	relpEngine_t *pThis;
@@ -325,7 +325,7 @@ static void dbgprintDummy(char LIBRELP_ATTR_UNUSED *fmt, ...) {}
  * function that already has been set, provide a NULL function pointer.
  * rgerhards, 2008-03-17
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetDbgprint(relpEngine_t *pThis, void (*dbgprint)(char *fmt, ...) LIBRELP_ATTR_FORMAT(printf, 1, 2))
 {
 	ENTER_RELPFUNC;
@@ -336,7 +336,7 @@ relpEngineSetDbgprint(relpEngine_t *pThis, void (*dbgprint)(char *fmt, ...) LIBR
 }
 
 
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetTLSLib(relpEngine_t *const pThis, NOTLS_UNUSED const int tls_lib)
 {
 	ENTER_RELPFUNC;
@@ -374,7 +374,7 @@ finalize_it:
 }
 
 
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetTLSLibByName(relpEngine_t *const pThis, const char *const name)
 {
 	ENTER_RELPFUNC;
@@ -408,7 +408,7 @@ finalize_it:
  * * relgEngineListnerConstructFinalize()
  * rgerhards, 2013-05-14
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineListnerConstruct(relpEngine_t *pThis, relpSrv_t **ppSrv)
 {
 	relpSrv_t *pSrv;
@@ -421,7 +421,7 @@ relpEngineListnerConstruct(relpEngine_t *pThis, relpSrv_t **ppSrv)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineListnerConstructFinalize(relpEngine_t *pThis, relpSrv_t *pSrv)
 {
 	ENTER_RELPFUNC;
@@ -449,7 +449,7 @@ static relpRetVal relpSrvSyslogRcvDummy2(void LIBRELP_ATTR_UNUSED *pUsr,
 /* set the syslog receive callback. If NULL is provided, it is set to the
  * not implemented dummy.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetSyslogRcv2(relpEngine_t *pThis, relpRetVal (*pCB)(void *, unsigned char*,
 	unsigned char*, unsigned char*, size_t))
 {
@@ -482,7 +482,7 @@ relpEngineSetSyslogRcv2(relpEngine_t *pThis, relpRetVal (*pCB)(void *, unsigned 
  * errmsg   - error message as far as librelp is concerned
  * errcode  - contains librelp error status that lead to the failed auth.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetOnAuthErr(relpEngine_t *pThis, void (*pCB)(void*pUsr, char *authinfo, char*errmsg, relpRetVal errcode) )
 {
 	ENTER_RELPFUNC;
@@ -506,7 +506,7 @@ relpEngineSetOnAuthErr(relpEngine_t *pThis, void (*pCB)(void*pUsr, char *authinf
  * errmsg   - error message as far as librelp is concerned
  * errcode  - contains librelp error status
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetOnErr(relpEngine_t *pThis, void (*pCB)(void*pUsr, char *objinfo, char*errmsg, relpRetVal errcode) )
 {
 	ENTER_RELPFUNC;
@@ -526,7 +526,7 @@ relpEngineSetOnErr(relpEngine_t *pThis, void (*pCB)(void*pUsr, char *objinfo, ch
  * errmsg   - error message as far as librelp is concerned
  * errcode  - contains librelp error status
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetOnGenericErr(relpEngine_t *pThis, void (*pCB)(char *objinfo, char*errmsg, relpRetVal errcode) )
 {
 	ENTER_RELPFUNC;
@@ -538,7 +538,7 @@ relpEngineSetOnGenericErr(relpEngine_t *pThis, void (*pCB)(char *objinfo, char*e
 /* Deprecated, use relpEngineListnerConstruct() family of functions.
  * See there for further information.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineAddListner2(relpEngine_t *pThis, unsigned char *pLstnPort, void *pUsr)
 {
 	relpSrv_t *pSrv = NULL;
@@ -566,7 +566,7 @@ static relpRetVal relpSrvSyslogRcvDummy(unsigned char LIBRELP_ATTR_UNUSED *pHost
 /* set the syslog receive callback. If NULL is provided, it is set to the
  * not implemented dummy.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetSyslogRcv(relpEngine_t *pThis, relpRetVal (*pCB)(unsigned char*, unsigned char*, unsigned char*, size_t))
 {
 	ENTER_RELPFUNC;
@@ -580,7 +580,7 @@ relpEngineSetSyslogRcv(relpEngine_t *pThis, relpRetVal (*pCB)(unsigned char*, un
 /* Deprecated, use relpEngineListnerConstruct() family of functions.
  * See there for further information.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineAddListner(relpEngine_t *pThis, unsigned char *pLstnPort)
 {
 	relpSrv_t *pSrv = NULL;
@@ -604,7 +604,7 @@ finalize_it:
  * signal is sent, it may take rather long to stop the server (until another
  * machine sends data).
  */
-relpRetVal relpEngineSetStop(relpEngine_t *pThis)
+relpRetVal PART_OF_API relpEngineSetStop(relpEngine_t *pThis)
 {
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Engine);
@@ -615,7 +615,7 @@ relpRetVal relpEngineSetStop(relpEngine_t *pThis)
 
 /* set the socket family to use
  */
-relpRetVal relpEngineSetFamily(relpEngine_t *pThis, int ai_family)
+relpRetVal PART_OF_API relpEngineSetFamily(relpEngine_t *pThis, int ai_family)
 {
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Engine);
@@ -1017,7 +1017,7 @@ engineEventLoopRun(relpEngine_t *pThis)
  * the several flavours of enhanced OS APIs.
  * rgerhards, 2008-03-17
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineRun(relpEngine_t *pThis)
 {
 	ENTER_RELPFUNC;
@@ -1051,7 +1051,7 @@ PROTOTYPEcommand(S, Syslog)
  * by this function - this must be done by the caller.
  * rgerhards, 2008-03-17
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineDispatchFrame(relpEngine_t *pThis, relpSess_t *pSess, relpFrame_t *pFrame)
 {
 	ENTER_RELPFUNC;
@@ -1097,7 +1097,7 @@ finalize_it:
  * users should always call the client-generating functions inside the engine.
  * rgerhards, 2008-03-19
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineCltConstruct(relpEngine_t *pThis, relpClt_t **ppClt)
 {
 	ENTER_RELPFUNC;
@@ -1116,7 +1116,7 @@ finalize_it:
  * relpEngineCltConstruct(), see comment there for details.
  * rgerhards, 2008-03-19
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineCltDestruct(relpEngine_t *pThis, relpClt_t **ppClt)
 {
 	ENTER_RELPFUNC;
@@ -1156,7 +1156,7 @@ relpEngineSetShutdownImmdtPtr(relpEngine_t *pThis, int *ptr)
  * it has been set to forbidden! There will be no error return state in this
  * case. -- rgerhards, 2008-03-27
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetEnableCmd(relpEngine_t *pThis, unsigned char *pszCmd, relpCmdEnaState_t stateCmd)
 {
 	ENTER_RELPFUNC;
@@ -1180,7 +1180,7 @@ finalize_it:
  * session. If disabled, the IP address will be used as the hostname.
  * rgerhards, 2008-03-31
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpEngineSetDnsLookupMode(relpEngine_t *pThis, int iMode)
 {
 	ENTER_RELPFUNC;

--- a/src/relp.h
+++ b/src/relp.h
@@ -1,6 +1,6 @@
 /* The RELP (reliable event logging protocol) core protocol library.
  *
- * Copyright 2008-2018 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2020 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -38,6 +38,8 @@
 #else
 	#define	NOTLS_UNUSED LIBRELP_ATTR_UNUSED
 #endif
+
+#define PART_OF_API __attribute__((visibility("default")))
 
 #include <pthread.h>
 #if HAVE_SYS_EPOLL_H

--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -1,6 +1,6 @@
 /* The relp client.
  *
- * Copyright 2008-2018 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2020 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -45,7 +45,7 @@
  * RELP function. The relp clt must only destructed after all RELP
  * operations have been finished.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltConstruct(relpClt_t **ppThis, relpEngine_t *pEngine)
 {
 	relpClt_t *pThis;
@@ -78,7 +78,7 @@ finalize_it:
 
 /** Destruct a RELP clt instance
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltDestruct(relpClt_t **ppThis)
 {
 	int i;
@@ -112,7 +112,7 @@ relpCltDestruct(relpClt_t **ppThis)
  * remote servers parameters must already have been set.
  * rgerhards, 2008-03-19
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltConnect(relpClt_t *pThis, int protFamily, unsigned char *port, unsigned char *host)
 {
 	ENTER_RELPFUNC;
@@ -155,7 +155,7 @@ finalize_it:
  * remote host) can not be changed.
  * rgerhards, 2008-03-23
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltReconnect(relpClt_t *pThis)
 {
 	ENTER_RELPFUNC;
@@ -172,7 +172,7 @@ finalize_it:
 /** Set the relp window size for this client. Value 0 means
  * that the default value is to be used.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetWindowSize(relpClt_t *pThis, int sizeWindow)
 {
 	ENTER_RELPFUNC;
@@ -186,7 +186,8 @@ finalize_it:
 }
 
 /** Set the timeout value for this client.  */
-relpRetVal relpCltSetTimeout(relpClt_t *pThis, unsigned timeout)
+relpRetVal PART_OF_API
+relpCltSetTimeout(relpClt_t *pThis, unsigned timeout)
 {
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Clt);
@@ -195,7 +196,8 @@ relpRetVal relpCltSetTimeout(relpClt_t *pThis, unsigned timeout)
 }
 
 /** Set the timeout value for this client socket connection.  */
-relpRetVal relpCltSetConnTimeout(relpClt_t *pThis, int connTimeout)
+relpRetVal PART_OF_API
+relpCltSetConnTimeout(relpClt_t *pThis, int connTimeout)
 {
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Clt);
@@ -211,7 +213,8 @@ finalize_it:
 
 /** Set the local IP address to be used when acting as a client.
  */
-relpRetVal relpCltSetClientIP(relpClt_t *pThis, unsigned char *ipAddr)
+relpRetVal PART_OF_API
+relpCltSetClientIP(relpClt_t *pThis, unsigned char *ipAddr)
 {
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Clt);
@@ -221,7 +224,7 @@ relpRetVal relpCltSetClientIP(relpClt_t *pThis, unsigned char *ipAddr)
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal
+relpRetVal PART_OF_API
 relpCltAddPermittedPeer(relpClt_t *pThis, char *peer)
 {
 	char **newName;
@@ -245,7 +248,7 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetUsrPtr(relpClt_t *pThis, void *pUsr)
 {
 	ENTER_RELPFUNC;
@@ -255,7 +258,7 @@ relpCltSetUsrPtr(relpClt_t *pThis, void *pUsr)
 }
 
 /* Note: mode==NULL is valid and means "no change" */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetAuthMode(relpClt_t *pThis, char *mode)
 {
 	ENTER_RELPFUNC;
@@ -279,7 +282,7 @@ finalize_it:
 /* set the GnuTLS priority string. Providing NULL does re-set
  * any previously set string. -- rgerhards, 2013-06-12
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetGnuTLSPriString(relpClt_t *pThis, char *pristr)
 {
 	ENTER_RELPFUNC;
@@ -294,7 +297,7 @@ relpCltSetGnuTLSPriString(relpClt_t *pThis, char *pristr)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetCACert(relpClt_t *pThis, char *file)
 {
 	ENTER_RELPFUNC;
@@ -309,7 +312,7 @@ relpCltSetCACert(relpClt_t *pThis, char *file)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetOwnCert(relpClt_t *pThis, char *file)
 {
 	ENTER_RELPFUNC;
@@ -324,7 +327,7 @@ relpCltSetOwnCert(relpClt_t *pThis, char *file)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetPrivKey(relpClt_t *pThis, char *file)
 {
 	ENTER_RELPFUNC;
@@ -339,7 +342,7 @@ relpCltSetPrivKey(relpClt_t *pThis, char *file)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSetTlsConfigCmd(relpClt_t *pThis, char *cfgcmd)
 {
 	ENTER_RELPFUNC;
@@ -356,7 +359,7 @@ finalize_it:
 
 }
 /* Enable TLS mode. */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltEnableTLS(relpClt_t *pThis)
 {
 	ENTER_RELPFUNC;
@@ -365,7 +368,7 @@ relpCltEnableTLS(relpClt_t *pThis)
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal
+relpRetVal PART_OF_API
 relpCltEnableTLSZip(relpClt_t *pThis)
 {
 	ENTER_RELPFUNC;
@@ -396,7 +399,7 @@ relpCltHintBurstEnd(relpClt_t *pThis)
  * must free it if it is no longer needed.
  * rgerhards, 2008-03-20
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpCltSendSyslog(relpClt_t *pThis, unsigned char *pMsg, size_t lenMsg)
 {
 

--- a/src/relpsrv.c
+++ b/src/relpsrv.c
@@ -47,7 +47,7 @@
  * RELP function. The relp srv must only destructed after all RELP
  * operations have been finished.
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvConstruct(relpSrv_t **ppThis, relpEngine_t *pEngine)
 {
 	relpSrv_t *pThis;
@@ -82,7 +82,7 @@ finalize_it:
 
 /** Destruct a RELP srv instance
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvDestruct(relpSrv_t **ppThis)
 {
 	relpSrv_t *pThis;
@@ -122,7 +122,7 @@ relpSrvDestruct(relpSrv_t **ppThis)
  * has been started. In that case, races can happen.
  * rgerhards, 2013-06-18
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvAddPermittedPeer(relpSrv_t *pThis, char *peer)
 {
 	char **newName;
@@ -150,7 +150,7 @@ finalize_it:
 /* set the user pointer. Whatever value the user provides is accepted.
  * rgerhards, 2008-07-08
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetUsrPtr(relpSrv_t *pThis, void *pUsr)
 {
 	ENTER_RELPFUNC;
@@ -159,14 +159,15 @@ relpSrvSetUsrPtr(relpSrv_t *pThis, void *pUsr)
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal relpSrvSetMaxDataSize(relpSrv_t *pThis, size_t maxSize) {
+relpRetVal PART_OF_API
+relpSrvSetMaxDataSize(relpSrv_t *pThis, size_t maxSize) {
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Srv);
 	pThis->maxDataSize = maxSize;
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal LIBRELP_ATTR_NONNULL()
+relpRetVal PART_OF_API LIBRELP_ATTR_NONNULL()
 relpSrvSetOversizeMode(relpSrv_t *const pThis, const int oversizeMode)
 {
 	ENTER_RELPFUNC;
@@ -186,7 +187,7 @@ finalize_it:
  * free the passed-in string.
  * rgerhards, 2008-03-17
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetLstnPort(relpSrv_t *pThis, unsigned char *pLstnPort)
 {
 	ENTER_RELPFUNC;
@@ -210,7 +211,7 @@ finalize_it:
  * free the passed-in string.
  * perlei, 2018-04-19
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetLstnAddr(relpSrv_t *pThis, unsigned char *pLstnAddr)
 {
 	ENTER_RELPFUNC;
@@ -230,7 +231,7 @@ finalize_it:
 }
 
 /* mode==NULL is valid and means "no change" */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetAuthMode(relpSrv_t *pThis, char *mode)
 {
 	ENTER_RELPFUNC;
@@ -254,7 +255,7 @@ finalize_it:
 /* set the IPv4/v6 type to be used. Default is both (PF_UNSPEC)
  * rgerhards, 2013-03-15
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetFamily(relpSrv_t *pThis, int ai_family)
 {
 	ENTER_RELPFUNC;
@@ -266,7 +267,7 @@ relpSrvSetFamily(relpSrv_t *pThis, int ai_family)
 /* set the GnuTLS priority string. Providing NULL does re-set
  * any previously set string. -- rgerhards, 2013-06-12
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetGnuTLSPriString(relpSrv_t *pThis, char *pristr)
 {
 	ENTER_RELPFUNC;
@@ -282,7 +283,7 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetCACert(relpSrv_t *pThis, char *cert)
 {
 	ENTER_RELPFUNC;
@@ -297,7 +298,7 @@ relpSrvSetCACert(relpSrv_t *pThis, char *cert)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetOwnCert(relpSrv_t *pThis, char *cert)
 {
 	ENTER_RELPFUNC;
@@ -312,7 +313,7 @@ relpSrvSetOwnCert(relpSrv_t *pThis, char *cert)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetPrivKey(relpSrv_t *pThis, char *cert)
 {
 	ENTER_RELPFUNC;
@@ -328,7 +329,7 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetTlsConfigCmd(relpSrv_t *pThis, char *cfgcmd)
 {
 	ENTER_RELPFUNC;
@@ -343,12 +344,12 @@ relpSrvSetTlsConfigCmd(relpSrv_t *pThis, char *cfgcmd)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-void
+void PART_OF_API
 relpSrvSetDHBits(relpSrv_t *pThis, int bits)
 {
 	pThis->dhBits = bits;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvEnableTLS2(relpSrv_t LIBRELP_ATTR_UNUSED *pThis)
 {
 	ENTER_RELPFUNC;
@@ -359,7 +360,7 @@ relpSrvEnableTLS2(relpSrv_t LIBRELP_ATTR_UNUSED *pThis)
 #endif /* #ifdef ENABLE_TLS | ENABLE_TLS_OPENSSL */
 	LEAVE_RELPFUNC;
 }
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvEnableTLSZip2(relpSrv_t LIBRELP_ATTR_UNUSED *pThis)
 {
 	ENTER_RELPFUNC;
@@ -381,7 +382,7 @@ relpSrvEnableTLSZip(relpSrv_t *pThis)
 	relpSrvEnableTLSZip2(pThis);
 }
 
-void
+void PART_OF_API
 relpSrvSetKeepAlive(relpSrv_t *pThis,
 	const int bEnabled,
 	const int iKeepAliveIntvl,
@@ -397,7 +398,7 @@ relpSrvSetKeepAlive(relpSrv_t *pThis,
 /* start a relp server - the server object must have all properties set
  * rgerhards, 2008-03-17
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvRun(relpSrv_t *pThis)
 {
 	relpTcp_t *pTcp;
@@ -443,7 +444,7 @@ finalize_it:
  * case.
  * rgerhards, 2008-03-27
  */
-relpRetVal
+relpRetVal PART_OF_API
 relpSrvSetEnableCmd(relpSrv_t *pThis, unsigned char *pszCmd, relpCmdEnaState_t stateCmd)
 {
 	ENTER_RELPFUNC;


### PR DESCRIPTION
closes https://github.com/rsyslog/librelp/issues/187