### PR TITLE
exported symbol bugfix: still some non-API functions were exported

### DIFF
--- a/src/relp.c
+++ b/src/relp.c
@@ -51,7 +51,7 @@
 
 /* ------------------------------ some internal functions ------------------------------ */
 
-void PART_OF_API LIBRELP_ATTR_FORMAT(printf, 4, 5)
+void LIBRELP_ATTR_FORMAT(printf, 4, 5)
 relpEngineCallOnGenericErr(relpEngine_t *const pThis, const char *eobj, relpRetVal ecode, const char *fmt, ...)
 {
 	va_list ap;
@@ -1053,7 +1053,7 @@ PROTOTYPEcommand(S, Syslog)
  * by this function - this must be done by the caller.
  * rgerhards, 2008-03-17
  */
-relpRetVal PART_OF_API
+relpRetVal
 relpEngineDispatchFrame(relpEngine_t *const pThis, relpSess_t *pSess, relpFrame_t *pFrame)
 {
 	ENTER_RELPFUNC;

--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -45,7 +45,7 @@
  * RELP function. The relp clt must only destructed after all RELP
  * operations have been finished.
  */
-relpRetVal PART_OF_API
+relpRetVal
 relpCltConstruct(relpClt_t **ppThis, relpEngine_t *const pEngine)
 {
 	relpClt_t *pThis;
@@ -78,7 +78,7 @@ finalize_it:
 
 /** Destruct a RELP clt instance
  */
-relpRetVal PART_OF_API
+relpRetVal
 relpCltDestruct(relpClt_t **ppThis)
 {
 	int i;

--- a/src/relpsrv.c
+++ b/src/relpsrv.c
@@ -47,7 +47,7 @@
  * RELP function. The relp srv must only destructed after all RELP
  * operations have been finished.
  */
-relpRetVal PART_OF_API
+relpRetVal
 relpSrvConstruct(relpSrv_t **ppThis, relpEngine_t *pEngine)
 {
 	relpSrv_t *pThis;
@@ -82,7 +82,7 @@ finalize_it:
 
 /** Destruct a RELP srv instance
  */
-relpRetVal PART_OF_API
+relpRetVal
 relpSrvDestruct(relpSrv_t **ppThis)
 {
 	relpSrv_t *pThis;
@@ -255,7 +255,7 @@ finalize_it:
 /* set the IPv4/v6 type to be used. Default is both (PF_UNSPEC)
  * rgerhards, 2013-03-15
  */
-relpRetVal PART_OF_API
+relpRetVal
 relpSrvSetFamily(relpSrv_t *const pThis, int ai_family)
 {
 	ENTER_RELPFUNC;
@@ -398,7 +398,7 @@ relpSrvSetKeepAlive(relpSrv_t *const pThis,
 /* start a relp server - the server object must have all properties set
  * rgerhards, 2008-03-17
  */
-relpRetVal PART_OF_API
+relpRetVal
 relpSrvRun(relpSrv_t *const pThis)
 {
 	relpTcp_t *pTcp;
@@ -435,32 +435,5 @@ finalize_it:
 			relpTcpDestruct(&pTcp);
 	}
 
-	LEAVE_RELPFUNC;
-}
-
-
-/* Enable or disable a command. Note that a command can not be enabled once
- * it has been set to forbidden! There will be no error return state in this
- * case.
- * rgerhards, 2008-03-27
- */
-relpRetVal PART_OF_API
-relpSrvSetEnableCmd(relpSrv_t *const pThis, unsigned char *const pszCmd, const relpCmdEnaState_t stateCmd)
-{
-	ENTER_RELPFUNC;
-	RELPOBJ_assert(pThis, Srv);
-	assert(pszCmd != NULL);
-
-pThis->pEngine->dbgprint((char*)"SRV SetEnableCmd in syslog cmd state: %d\n", pThis->stateCmdSyslog);
-	if(!strcmp((char*)pszCmd, "syslog")) {
-		if(pThis->stateCmdSyslog != eRelpCmdState_Forbidden)
-			pThis->stateCmdSyslog = stateCmd;
-	} else {
-		pThis->pEngine->dbgprint((char*)"tried to set unknown command '%s' to %d\n", pszCmd, stateCmd);
-		ABORT_FINALIZE(RELP_RET_UNKNOWN_CMD);
-	}
-
-finalize_it:
-pThis->pEngine->dbgprint((char*)"SRV SetEnableCmd out syslog cmd state: %d, iRet %d\n", pThis->stateCmdSyslog, iRet);
 	LEAVE_RELPFUNC;
 }


### PR DESCRIPTION
Thanks to Michael Biebl for pointing this out.

see also: https://github.com/rsyslog/librelp/issues/187#issuecomment-680974232