### PR TITLE
gnutls: added call for gnutls_certificate_free_credentials

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -668,6 +668,9 @@ relpTcpConstruct(relpTcp_t **ppThis, relpEngine_t *const pEngine,
 	pThis->pUsr = NULL;
 	pThis->permittedPeers.nmemb = 0;
 	pThis->permittedPeers.peer = NULL;
+	#ifdef ENABLE_TLS
+	pThis->xcred = NULL;
+	#endif
 
 	*ppThis = pThis;
 
@@ -689,6 +692,10 @@ relpTcpDestructTLS_gtls(relpTcp_t *pThis)
 		sslRet = gnutls_bye(pThis->session, GNUTLS_SHUT_RDWR);
 	}
 	gnutls_deinit(pThis->session);
+	if (pThis->xcred != NULL) {
+		gnutls_certificate_free_credentials(pThis->xcred);
+	}
+
 	LEAVE_RELPFUNC;
 }
 #else


### PR DESCRIPTION
In relpTcpDestructTLS_gtls which fixes a memory leak in gnutls driver.

closes: https://github.com/rsyslog/librelp/issues/194