### PR TITLE
gnutls "bugfix": handle receives who break connection on close

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -687,9 +687,9 @@ relpTcpDestructTLS_gtls(relpTcp_t *pThis)
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Tcp);
 
-	sslRet = gnutls_bye(pThis->session, GNUTLS_SHUT_RDWR);
+	sslRet = gnutls_bye(pThis->session, GNUTLS_SHUT_WR);
 	while(sslRet == GNUTLS_E_INTERRUPTED || sslRet == GNUTLS_E_AGAIN) {
-		sslRet = gnutls_bye(pThis->session, GNUTLS_SHUT_RDWR);
+		sslRet = gnutls_bye(pThis->session, GNUTLS_SHUT_WR);
 	}
 	gnutls_deinit(pThis->session);
 	if (pThis->xcred != NULL) {


### PR DESCRIPTION
Some TLS servers don't reply to graceful shutdown requests "for
optimization". This can lead to librelp keeping the connection
for ever and thus effectively to hang on it.

This patch is modelled after a simuilar patch by Renaud Métrich
for rsyslog.

see also https://github.com/rsyslog/rsyslog/pull/4424