### PR TITLE
openssl: fix preprocessor check for tlsconfigcmd code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,7 +123,7 @@ AC_CHECK_MEMBERS([struct sockaddr.sa_len],,,[$sa_includes])
 AC_FUNC_SELECT_ARGTYPES
 AC_FUNC_STRERROR_R
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS([strerror_r strdup epoll_create epoll_create1])
+AC_CHECK_FUNCS([strerror_r strdup strndup epoll_create epoll_create1])
 
 # enable TLS (may not be possible on platforms with too-old GnuTLS)
 AC_ARG_ENABLE(tls,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,7 +44,8 @@ librelp_la_SOURCES = \
 	cclose.c \
 	cserverclose.c \
 	dbllinklist.h \
-	cmdif.h
+	cmdif.h \
+	compat/strndup.c
 librelp_la_CPPFLAGS = $(AM_CLFAGS) $(PTHREADS_CFLAGS) $(GNUTLS_CFLAGS) $(OPENSSL_CFLAGS) $(WARN_CFLAGS)
 librelp_la_LIBADD = $(rt_libs) $(GNUTLS_LIBS) $(OPENSSL_LIBS)
 # info on version-info:

--- a/src/compat/strndup.c
+++ b/src/compat/strndup.c
@@ -1,0 +1,47 @@
+/* compatibility file for systems without strndup.
+ *
+ * Copyright 2015 Rainer Gerhards and Adiscon
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#ifndef HAVE_STRNDUP
+
+
+#include <stdlib.h>
+#include <string.h>
+
+extern char *strndup(const char *s, size_t n);
+
+char *
+strndup(const char *s, size_t n)
+{
+	const size_t len = strlen(s);
+	char *new_s;
+	if(len <= n)
+		return strdup(s);
+	new_s = malloc(n+1);
+	if(new_s == NULL)
+		return NULL;
+	memcpy(new_s, s, n);
+	new_s[n] = '\0';
+	return new_s;
+}
+#else
+/* ISO C forbids an empty translation unit */
+static __attribute__((unused)) void dummystrndup(void) {}
+#endif /* #ifndef HAVE_STRNDUP */

--- a/src/relp.h
+++ b/src/relp.h
@@ -235,4 +235,14 @@ void LIBRELP_ATTR_FORMAT(printf, 4, 5) relpEngineCallOnGenericErr(relpEngine_t *
 	const char *eobj, relpRetVal ecode, const char *fmt, ...);
 const char * _relpEngine_strerror_r(const int errnum, char *buf, const size_t buflen);
 
+/* here we add some stuff from the compatibility layer. A separate include
+ * would be cleaner, but would potentially require changes all over the
+ * place. So doing it here is better. The respective replacement
+ * functions should usually be found under ./compat -- rgerhards, 2015-05-20
+ * - Function copied from rsyslog -- alorbach, 2020-11-13
+ */
+#ifndef HAVE_STRNDUP
+char * strndup(const char *s, size_t n);
+#endif
+
 #endif /* #ifndef RELP_H_INCLUDED */

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1630,7 +1630,7 @@ relpTcpSetSslConfCmd_ossl(relpTcp_t *const pThis, char *tlsConfigCmd)
 	} else {
 		pThis->pEngine->dbgprint((char*)"relpTcpSetSslConfCmd_ossl: set to '%s'\n", tlsConfigCmd);
 		char errmsg[1424];
-#if OPENSSL_VERSION_NUMBER >= 0x10020000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
 		char *pCurrentPos;
 		char *pNextPos;
 		char *pszCmd;

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -129,7 +129,7 @@ check_output() {
 	grep $3 "$EXPECTED" $FILE_TO_CHECK > /dev/null
 	if [ $? -ne 0 ]; then
 		if [ "$check_only" == "yes" ]; then
-			printf 'check_output did not yet succeed in %s (check_only set)\n', $FILE_TO_CHECK
+			printf 'check_output did not yet succeed for "%s" in "%s" (check_only set)\n', "$EXPECTED", "$FILE_TO_CHECK"
 			return 1
 		fi
 		printf "\nFAIL: expected message not found. Expected:\n"

--- a/tests/tls-basic-tlscommand.sh
+++ b/tests/tls-basic-tlscommand.sh
@@ -29,7 +29,7 @@ function actual_test() {
 				exit 77
 			else
 				# Try "handshake failed" first
-				check_output --check-only "handshake failed" $TESTDIR/$errorlog
+				check_output --check-only "handshake fail" $TESTDIR/$errorlog
 				ret=$?
 				if [ $ret != 0 ]; then
 					check_output "wrong version number" $TESTDIR/$errorlog


### PR DESCRIPTION
tls config commands no is compiled for OpenSSL 1.0.2.

closes: https://github.com/rsyslog/librelp/issues/221