### PR TITLE
openssl: Fix tlscommand support for ciphers.

### DIFF
--- a/src/offers.c
+++ b/src/offers.c
@@ -218,7 +218,7 @@ relpOfferValueAdd(unsigned char *pszVal, int intVal, relpOffer_t *pOffer)
 		snprintf((char*)pThis->szVal, sizeof(pThis->szVal), "%d", intVal);
 		pThis->intVal = intVal;
 	} else {
-		strncpy((char*)pThis->szVal, (char*)pszVal, sizeof(pThis->szVal));
+		strncpy((char*)pThis->szVal, (char*)pszVal, sizeof(pThis->szVal) - 1);
 		/* check if the string actually is an integer... */
 		Val = 0;
 		i = 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,6 +26,7 @@ TLS_TESTS=  \
 	tls-basic-fingerprint.sh \
 	tls-basic-wildcard.sh \
 	tls-basic-tlscommand.sh \
+	tls-basic-tlscommand-ciphers.sh \
 	tls-basic-certchain.sh \
 	tls-basic-certvalid-mixed.sh \
 	tls-receiver-abort.sh \

--- a/tests/tls-basic-tlscommand-ciphers.sh
+++ b/tests/tls-basic-tlscommand-ciphers.sh
@@ -10,18 +10,18 @@ function actual_test() {
 			-y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem \
 			-P 'testbench.rsyslog.com' \
 			--errorfile $TESTDIR/$errorlog \
-			-c "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2;CipherString=ECDHE-RSA-AES256-GCM-SHA384;Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2,-TLSv1.3;MinProtocol=TLSv1.2;MaxProtocol=TLSv1.2"
+			-c "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.1;CipherString=ECDHE-RSA-AES256-GCM-SHA384;MinProtocol=TLSv1.2;MaxProtocol=TLSv1.2;Ciphersuites=TLS_AES_256_GCM_SHA384"
 
 		echo 'Send Message...'
 		./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" \
 			-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
 			-z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' \
-			-c "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1.1,-TLSv1.2;CipherString=DHE-RSA-AES256-SHA;Protocol=ALL,-SSLv2,-SSLv3,-TLSv1.1,-TLSv1.2,-TLSv1.3;MinProtocol=TLSv1.1;MaxProtocol=TLSv1.1" \
+			-c "CipherString=ECDHE-RSA-AES128-GCM-SHA256;Ciphersuites=TLS_AES_128_GCM_SHA256" \
 			--errorfile $TESTDIR/$errorlog \
 			$OPT_VERBOSE
 
 		stop_receiver
-	
+
 		if test -f $TESTDIR/$errorlog; then
 			check_output --check-only "OpenSSL Version too old" $TESTDIR/$errorlog
 			ret=$?


### PR DESCRIPTION
When the client tried to conntect to the server, custom cipherstrings (Set by tlscommands feature) were not used. This could lead to the negotiation of different and potentially weaker ciphers. Other custom tlscommands settings like Protocol where not affected. We do not overwrite the custom ciphers anymore if they are set by tlscommands. Another problem only related to the relp receiver (server) was, that the custom tlscommands/priority string where not applied on the accepted client connections. This could lead to the same problem as the default ciphers were used.

Besides the main problem, the following changes were applied:
- Add new testcase for setting custom tls ciphers in tlscommand.
- Add support to use semicolon (;) as tlscommand seperator (See new testcase)
- Fix GCC9 "destination size" warning in offers.c

closes: https://github.com/rsyslog/librelp/issues/224