### PR TITLE
Make relpEngineSetTLSLib debug safe

### DIFF
--- a/src/relp.c
+++ b/src/relp.c
@@ -369,7 +369,8 @@ relpEngineSetTLSLib(relpEngine_t *const pThis, NOTLS_UNUSED const int tls_lib)
 	#endif
 
 finalize_it:
-	pThis->dbgprint((char*)"relpEngineSetTLSLib, lib now %d, ret %d\n", pThis->tls_lib, iRet);
+	if (pThis)
+		pThis->dbgprint((char*)"relpEngineSetTLSLib, lib now %d, ret %d\n", pThis->tls_lib, iRet);
 	LEAVE_RELPFUNC;
 }
 


### PR DESCRIPTION
In case ```pThis == NULL``` condition is true at line https://github.com/rsyslog/librelp/blob/master/src/relp.c#L345 , ```pThis->dbgprint(...)``` would cause unexpected behavior.