### PR TITLE
testbench: Added compatiblity to run on AIX

### DIFF
--- a/.github/workflows/rsyslog.yml
+++ b/.github/workflows/rsyslog.yml
@@ -111,6 +111,8 @@ jobs:
           autoreconf -fvi
           ./configure \
                 --disable-default-tests \
+                --disable-imfile-tests \
+                --disable-fmhttp \
                 --enable-imdiag \
                 --enable-omstdout \
                 --enable-relp \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 TEST_EXTENSIONS=.sh
-check_PROGRAMS=receive send chkseq have_tlslib
+check_PROGRAMS=receive send chkseq have_tlslib msleep
 
 receive_SOURCES=receive.c
 receive_LDADD=../src/.libs/librelp.la
@@ -8,6 +8,8 @@ receive_CFLAGS=$(AM_CFLAGS) -I${top_srcdir}/src $(WARN_CFLAGS)
 send_SOURCES=send.c
 send_LDADD=../src/.libs/librelp.la
 send_CFLAGS=$(AM_CFLAGS) -I${top_srcdir}/src $(WARN_CFLAGS)
+
+msleep_SOURCES = msleep.c
 
 chkseq_SOURCES=chkseq.c
 have_tlslib_SOURCES=have_tlslib.c

--- a/tests/basic-sessionbreak-vg.sh
+++ b/tests/basic-sessionbreak-vg.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 . ${srcdir:=$(pwd)}/test-framework.sh
+check_command_available valgrind
+
 if [ "$VALGRIND" == "NO" ] ; then
    echo "valgrind tests are not permitted by environment config"
    exit 77
@@ -18,12 +20,12 @@ export NUMLOOPS=2
 #export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
 export valgrind="valgrind --malloc-fill=ff --free-fill=fe --leak-check=full --log-fd=1 --error-exitcode=10 --gen-suppressions=all"
 	
-startup_receiver_valgrind --no-exit-on-error -e error.out.log --outfile $OUTFILE
+startup_receiver_valgrind -N -e error.out.log -O $OUTFILE
 
 echo 'Send Message(s)...'
 for i in $(seq 1 $NUMLOOPS); do 
         # How many times tcpflood runs in each threads
-	libtool --mode=execute ./send --no-exit-on-error -t 127.0.0.1 -p $TESTPORT -m "testmessage" -n $NUMMESSAGES $OPT_VERBOSE &
+	libtool --mode=execute ./send -N -t 127.0.0.1 -p $TESTPORT -m "testmessage" -n $NUMMESSAGES $OPT_VERBOSE &
 	send_pid=$!
 
 	echo "started send instance $i (PID $send_pid)"

--- a/tests/duplicate-receiver-vg.sh
+++ b/tests/duplicate-receiver-vg.sh
@@ -9,6 +9,8 @@ listen port cannot be bound to.
 EOF
 exit 77
 . ${srcdir:=$(pwd)}/test-framework.sh
+check_command_available valgrind
+
 if [ "$VALGRIND" == "NO" ] ; then
    echo "valgrind tests are not permitted by environment config"
    exit 77

--- a/tests/msleep.c
+++ b/tests/msleep.c
@@ -1,0 +1,58 @@
+/* sleeps for the specified number of MILLIseconds.
+ * Primarily meant as a portable tool available everywhere for the
+ * testbench (sleep 0.1 does not work on all platforms).
+ *
+ * Part of the testbench for rsyslog.
+ *
+ * Copyright 2010 Rainer Gerhards and Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Rsyslog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rsyslog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rsyslog.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * A copy of the GPL can be found in the file "COPYING" in this distribution.
+ */
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#if defined(__FreeBSD__)
+#include <sys/time.h>
+#else
+#include <time.h>
+#endif
+#if defined(HAVE_SYS_SELECT_H)
+#include <sys/select.h>
+#endif
+
+int main(int argc, char *argv[])
+{
+	struct timeval tvSelectTimeout;
+	long sleepTime;
+
+	if(argc != 2) {
+		fprintf(stderr, "usage: msleep <milliseconds>\n");
+		exit(1);
+	}
+
+	sleepTime = atoi(argv[1]);
+	tvSelectTimeout.tv_sec = sleepTime / 1000;
+	tvSelectTimeout.tv_usec = (sleepTime % 1000) * 1000; /* micro seconds */
+	if(select(0, NULL, NULL, NULL, &tvSelectTimeout) == -1) {
+		perror("select");
+		exit(1);
+	}
+
+	return 0;
+}
+

--- a/tests/receive-emptyconnect.sh
+++ b/tests/receive-emptyconnect.sh
@@ -5,8 +5,9 @@
 # written 2018-11-20 by Rainer Gerhards, released under ASL 2.0
 . ${srcdir:=$(pwd)}/test-framework.sh
 export errorlog="error.$LIBRELP_DYN.log"
+check_command_available timeout
 
-startup_receiver --errorfile $TESTDIR/$errorlog
+startup_receiver -e $TESTDIR/$errorlog
 timeout 10s $PYTHON ${srcdir}/dummyclient.py
 sleep 1
 stop_receiver

--- a/tests/receive.c
+++ b/tests/receive.c
@@ -24,7 +24,11 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <unistd.h>
-#include <getopt.h>
+#if defined(_AIX)
+#	include  <unistd.h>
+#else
+#	include <getopt.h>
+#endif
 #include <string.h>
 #include <limits.h>
 #include <errno.h>
@@ -239,6 +243,9 @@ int main(int argc, char *argv[]) {
 	const char *tlslib = NULL;
 	const char* outfile_name = NULL;
 
+#if defined(_AIX)
+	while((c = getopt(argc, argv, "a:c:Ae:F:l:m:No:O:P:p:TvW:x:y:z:")) != EOF) {
+#else
 	static struct option long_options[] =
 	{
 		{"ca", required_argument, 0, 'x'},
@@ -257,9 +264,8 @@ int main(int argc, char *argv[]) {
 		{0, 0, 0, 0}
 	};
 
-
-	while((c = getopt_long(argc, argv, "a:c:Ae:F:l:m:o:O:P:p:TvW:x:y:z:",
-		long_options, &option_index)) != -1) {
+	while((c = getopt_long(argc, argv, "a:c:Ae:F:l:m:No:O:P:p:TvW:x:y:z:", long_options, &option_index)) != -1) {
+#endif
 		switch(c) {
 		case 'a':
 			authMode = optarg;

--- a/tests/receiver-abort.sh
+++ b/tests/receiver-abort.sh
@@ -9,7 +9,7 @@ export NUMMESSAGES=100000
 check_command_available timeout
 
 startup_receiver -e ${TESTDIR}/${errorlog}
-./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES --no-exit-on-error --kill-on-msg 20000 --kill-pid $RECEIVE_PID $OPT_VERBOSE &
+./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES -N -K 20000 -I $RECEIVE_PID $OPT_VERBOSE &
 SENDER_PID=$!
 
 for i in {1..3};  do

--- a/tests/selftest_receive_watchdog.sh
+++ b/tests/selftest_receive_watchdog.sh
@@ -2,7 +2,7 @@
 # written 2018-11-28 by Rainer Gerhards, released under ASL 2.0
 . ${srcdir:=$(pwd)}/test-framework.sh
 printf 'starting receive, waiting for watchdog timeout to occur\n'
-./receive --watchdog-timeout 2 -p $TESTPORT &> $OUTFILE
+./receive -W 2 -p $TESTPORT &> $OUTFILE
 cat $OUTFILE
 check_output "watchdog timer expired"
 terminate

--- a/tests/send.c
+++ b/tests/send.c
@@ -24,7 +24,11 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <unistd.h>
-#include <getopt.h>
+#if defined(_AIX)
+#	include  <unistd.h>
+#else
+#	include <getopt.h>
+#endif
 #include <string.h>
 #include <sys/types.h>
 #include <signal.h>
@@ -255,11 +259,14 @@ int main(int argc, char *argv[]) {
 	under_ci = getenv("UNDER_CI");
 	dbgFile = stdout;
 
-	#define KILL_ON_MSG	256
-	#define KILL_SIGNAL	257
-	#define KILL_PID	258
-	#define DBGFILE		259
-	#define CONNECT_RETRIES	260
+	#define KILL_ON_MSG	'K'
+	#define KILL_SIGNAL	'S'
+	#define KILL_PID	'I'
+	#define DBGFILE		'D'
+	#define CONNECT_RETRIES	'R'
+#if defined(_AIX)
+	while((c = getopt(argc, argv, "a:c:e:d:D:I:K:l:m:n:NP:p:R:S:Tt:vx:y:z:")) != EOF) {
+#else
 	static struct option long_options[] =
 	{
 		{"ca", required_argument, 0, 'x'},
@@ -280,7 +287,8 @@ int main(int argc, char *argv[]) {
 		{0, 0, 0, 0}
 	};
 
-	while((c = getopt_long(argc, argv, "a:c:e:d:l:m:n:P:p:Tt:vx:y:z:", long_options, &option_index)) != -1) {
+	while((c = getopt_long(argc, argv, "a:c:e:d:D:I:K:l:m:n:NP:p:R:S:Tt:vx:y:z:", long_options, &option_index)) != -1) {
+#endif
 		switch(c) {
 		case 'a':
 			authMode = optarg;

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -49,7 +49,7 @@ check_command_available() {
 wait_process_startup_via_pidfile() {
 	i=0
 	while test ! -f $1 ; do
-		sleep .100
+		./msleep 100
 		(( i++ ))
 		if test $i -gt $TB_TIMEOUT_STARTUP
 		then
@@ -68,7 +68,7 @@ startup_receiver_valgrind() {
 		exit 77
 	fi
 	printf 'Starting Receiver...\n'
-	libtool --mode=execute $valgrind ./receive $TLSLIB -p $TESTPORT --outfile $OUTFILE.2 -F $RECEIVE_PIDFILE $OPT_VERBOSE $* &
+	libtool --mode=execute $valgrind ./receive $TLSLIB -p $TESTPORT -O $OUTFILE.2 -F $RECEIVE_PIDFILE $OPT_VERBOSE $* &
 	export RECEIVE_PID=$!
 	printf "got $RECEIVE_PID $RECEIVE_PIDFILE\n"
 	wait_process_startup_via_pidfile $RECEIVE_PIDFILE
@@ -78,7 +78,7 @@ startup_receiver_valgrind() {
 # start receiver, add receiver command line parameters after function name
 startup_receiver() {
 	printf 'Starting Receiver...\n'
-	./receive $TLSLIB -p $TESTPORT -F $RECEIVE_PIDFILE --outfile $OUTFILE $OPT_VERBOSE $* &
+	./receive $TLSLIB -p $TESTPORT -F $RECEIVE_PIDFILE -O $OUTFILE $OPT_VERBOSE $* &
 	export RECEIVE_PID=$!
 	printf "got $RECEIVE_PID $RECEIVE_PIDFILE\n"
 	wait_process_startup_via_pidfile $RECEIVE_PIDFILE
@@ -153,7 +153,7 @@ wait_testport_available() {
 		if ! netstat -tp | grep -q $TESTPORT; then
 			break
 		fi
-		sleep 1
+		./msleep 1000
 	done
 }
 

--- a/tests/tls-basic-anon.sh
+++ b/tests/tls-basic-anon.sh
@@ -2,10 +2,10 @@
 . ${srcdir:=$(pwd)}/test-framework.sh
 
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -e error.out.log
+	startup_receiver -l $TEST_TLS_LIB -T -e error.out.log
 
 	echo 'Send Message...'
-	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T $OPT_VERBOSE 1>>${OUTFILE} 2>&1
+	./send -l $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T $OPT_VERBOSE 1>>${OUTFILE} 2>&1
 
 	# "relpTcpLastSSLErrorMsg: Errorstack: error:1417A0C1:SSL routines:tls_post_process_client_hello:no shared cipher"
 	stop_receiver

--- a/tests/tls-basic-certchain.sh
+++ b/tests/tls-basic-certchain.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 . ${srcdir:=$(pwd)}/test-framework.sh
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "certvalid" -y ${srcdir}/tls-certs/ossl-server-certchain.pem -z ${srcdir}/tls-certs/ossl-server-key.pem  -e error.out.log
+	startup_receiver -l $TEST_TLS_LIB -T -a "certvalid" -y ${srcdir}/tls-certs/ossl-server-certchain.pem -z ${srcdir}/tls-certs/ossl-server-key.pem  -e error.out.log
 
 	echo 'Send Message...'
-	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -y ${srcdir}/tls-certs/ossl-client-certchain.pem -z ${srcdir}/tls-certs/ossl-client-key.pem $OPT_VERBOSE 1>>${OUTFILE} 2>&1
+	./send -l $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -y ${srcdir}/tls-certs/ossl-client-certchain.pem -z ${srcdir}/tls-certs/ossl-client-key.pem $OPT_VERBOSE 1>>${OUTFILE} 2>&1
 
 	stop_receiver
 	check_output "testmessage"

--- a/tests/tls-basic-certvalid-mixed.sh
+++ b/tests/tls-basic-certvalid-mixed.sh
@@ -12,11 +12,11 @@ if ! ./have_tlslib "openssl"; then
 	exit;
 fi
 
-startup_receiver --tls-lib openssl -T -a "certvalid" -e "${TESTDIR}/${errorlog}" \
+startup_receiver -l openssl -T -a "certvalid" -e "${TESTDIR}/${errorlog}" \
 		-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem
 
 echo 'Send Message...'
-./send --tls-lib gnutls -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -e "${TESTDIR}/${errorlog}" \
+./send -l gnutls -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -e "${TESTDIR}/${errorlog}" \
 	-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem $OPT_VERBOSE 1>>${OUTFILE} 2>&1
 
 stop_receiver

--- a/tests/tls-basic-certvalid.sh
+++ b/tests/tls-basic-certvalid.sh
@@ -3,10 +3,10 @@
 export errorlog="error.$LIBRELP_DYN.log"
 
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "certvalid" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem  --errorfile "${TESTDIR}/${errorlog}"
+	startup_receiver -l $TEST_TLS_LIB -T -a "certvalid" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem  -e "${TESTDIR}/${errorlog}"
 
 	echo 'Send Message...'
-	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem $OPT_VERBOSE 1>>${OUTFILE} 2>&1
+	./send -l $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "certvalid" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem $OPT_VERBOSE 1>>${OUTFILE} 2>&1
 
 	stop_receiver
 	check_output "testmessage"

--- a/tests/tls-basic-fingerprint.sh
+++ b/tests/tls-basic-fingerprint.sh
@@ -2,10 +2,10 @@
 . ${srcdir:=$(pwd)}/test-framework.sh
 
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "fingerprint" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3' -e error.out.log
+	startup_receiver -l $TEST_TLS_LIB -T -a "fingerprint" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3' -e error.out.log
 
 	echo 'Send Message...'
-	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "fingerprint" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3' $OPT_VERBOSE 1>>${OUTFILE} 2>&1
+	./send -l $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "fingerprint" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3' $OPT_VERBOSE 1>>${OUTFILE} 2>&1
 
 	stop_receiver
 	check_output "testmessage"

--- a/tests/tls-basic-realistic.sh
+++ b/tests/tls-basic-realistic.sh
@@ -6,12 +6,13 @@
 NUMMESSAGES=50000
 
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
+	startup_receiver -l $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
 		-y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem \
 		-P 'testbench.rsyslog.com' -e error.out.log
-	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES -T -a "name" \
+	./send -l $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES -T -a "name" \
 		-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
 		-z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' $OPT_VERBOSE
+	./msleep 1000
 	stop_receiver
 	check_msg_count
 	printf 'END SUBTEST lib %s SUCCESS\n' $TEST_TLS_LIB

--- a/tests/tls-basic-tlscommand-ciphers.sh
+++ b/tests/tls-basic-tlscommand-ciphers.sh
@@ -9,7 +9,7 @@ function actual_test() {
 		startup_receiver --tls-lib $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
 			-y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem \
 			-P 'testbench.rsyslog.com' \
-			--errorfile $TESTDIR/$errorlog \
+			-e  $TESTDIR/$errorlog \
 			-c "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.1;CipherString=ECDHE-RSA-AES256-GCM-SHA384;MinProtocol=TLSv1.2;MaxProtocol=TLSv1.2;Ciphersuites=TLS_AES_256_GCM_SHA384"
 
 		echo 'Send Message...'
@@ -17,7 +17,7 @@ function actual_test() {
 			-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
 			-z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' \
 			-c "CipherString=ECDHE-RSA-AES128-GCM-SHA256;Ciphersuites=TLS_AES_128_GCM_SHA256" \
-			--errorfile $TESTDIR/$errorlog \
+			-e $TESTDIR/$errorlog \
 			$OPT_VERBOSE
 
 		stop_receiver

--- a/tests/tls-basic-tlscommand.sh
+++ b/tests/tls-basic-tlscommand.sh
@@ -9,7 +9,7 @@ function actual_test() {
 		startup_receiver --tls-lib $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
 			-y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem \
 			-P 'testbench.rsyslog.com' \
-			--errorfile $TESTDIR/$errorlog \
+			-e $TESTDIR/$errorlog \
 			-c "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2;CipherString=ECDHE-RSA-AES256-GCM-SHA384;Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2,-TLSv1.3;MinProtocol=TLSv1.2;MaxProtocol=TLSv1.2"
 
 		echo 'Send Message...'
@@ -17,7 +17,7 @@ function actual_test() {
 			-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
 			-z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' \
 			-c "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1.1,-TLSv1.2;CipherString=DHE-RSA-AES256-SHA;Protocol=ALL,-SSLv2,-SSLv3,-TLSv1.1,-TLSv1.2,-TLSv1.3;MinProtocol=TLSv1.1;MaxProtocol=TLSv1.1" \
-			--errorfile $TESTDIR/$errorlog \
+			-e $TESTDIR/$errorlog \
 			$OPT_VERBOSE
 
 		stop_receiver

--- a/tests/tls-basic-vg.sh
+++ b/tests/tls-basic-vg.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 . ${srcdir:=$(pwd)}/test-framework.sh
+check_command_available valgrind
 if [ "$VALGRIND" == "NO" ] ; then
    echo "valgrind tests are not permitted by environment config"
    exit 77
@@ -14,13 +15,13 @@ if [ $(uname) = "FreeBSD" ] ; then
 fi
 
 function actual_test() {
-	startup_receiver_valgrind --tls-lib $TEST_TLS_LIB -T -a "name" -e error.out.log --outfile $OUTFILE \
+	startup_receiver_valgrind -l $TEST_TLS_LIB -T -a "name" -e error.out.log -O $OUTFILE \
 		-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
 		-z ${srcdir}/tls-certs/key.pem -P "rsyslog-client"
 
 	echo 'Send Message...'
 	libtool --mode=execute $valgrind \
-		./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T \
+		./send -l $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T \
 		-a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
 		-z ${srcdir}/tls-certs/key.pem -P "rsyslog-client" $OPT_VERBOSE
 

--- a/tests/tls-basic-wildcard.sh
+++ b/tests/tls-basic-wildcard.sh
@@ -2,10 +2,10 @@
 . ${srcdir:=$(pwd)}/test-framework.sh
 
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P '*.rsyslog.com' -e error.out.log
+	startup_receiver -l $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P '*.rsyslog.com' -e error.out.log
 
 	echo 'Send Message...'
-	./send -t 127.0.0.1 --tls-lib $TEST_TLS_LIB -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P '*.rsyslog.com' $OPT_VERBOSE
+	./send -t 127.0.0.1 -l $TEST_TLS_LIB -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P '*.rsyslog.com' $OPT_VERBOSE
 
 	stop_receiver
 	check_output "testmessage"

--- a/tests/tls-basic.sh
+++ b/tests/tls-basic.sh
@@ -2,11 +2,11 @@
 . ${srcdir:=$(pwd)}/test-framework.sh
 
 function actual_test() {
-	startup_receiver --tls-lib $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
+	startup_receiver -l $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
 		-y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem \
 		-P 'testbench.rsyslog.com' -e error.out.log
 
-	./send --tls-lib $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" \
+	./send -l $TEST_TLS_LIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" \
 		-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
 		-z ${srcdir}/tls-certs/key.pem -P 'testbench.rsyslog.com' $OPT_VERBOSE
 

--- a/tests/tls-missing-param-receiver.sh
+++ b/tests/tls-missing-param-receiver.sh
@@ -5,7 +5,7 @@ echo 'Start Receiver...'
 
 function actual_test() {
 	# NOT USING startup_receiver!
-	./receive --tls-lib $TEST_TLS_LIB -p $TESTPORT -T -a "name" \
+	./receive -l $TEST_TLS_LIB -p $TESTPORT -T -a "name" \
 		-y ${srcdir}/tls-certs/cert.pem -P "rsyslog" \
 		2> $OUTFILE
 

--- a/tests/tls-receiver-abort.sh
+++ b/tests/tls-receiver-abort.sh
@@ -8,8 +8,8 @@ export NUMMESSAGES=100000
 
 actual_test() {
 	startup_receiver
-	./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES --no-exit-on-error \
-		--kill-on-msg 20000 --kill-pid $RECEIVE_PID $OPT_VERBOSE &
+	./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES -N \
+		-K 20000 -I$RECEIVE_PID $OPT_VERBOSE &
 	SENDER_PID=$!
 
 	for i in {1..3};  do

--- a/tests/tls-wrong-permittedPeer.sh
+++ b/tests/tls-wrong-permittedPeer.sh
@@ -9,7 +9,7 @@ startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ca.pem \
 echo 'Send Message...'
 ./send $TLSLIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" \
 	-x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem \
-	-z ${srcdir}/tls-certs/key.pem -P "wrong name" --errorfile $TESTDIR/$errorlog $OPT_VERBOSE
+	-z ${srcdir}/tls-certs/key.pem -P "wrong name" -e $TESTDIR/$errorlog $OPT_VERBOSE
 
 stop_receiver
 check_output "authentication error.*no permited name found.*testbench.rsyslog.com" $TESTDIR/$errorlog

--- a/tests/tls-wrong-signedcert.sh
+++ b/tests/tls-wrong-signedcert.sh
@@ -5,7 +5,7 @@ export TLSLIB="--tls-lib openssl"
 startup_receiver -T -a "name" -x ${srcdir}/tls-certs/ossl-ca.pem -y ${srcdir}/tls-certs/ossl-server-cert.pem -z ${srcdir}/tls-certs/ossl-server-key.pem -P 'client.testbench.rsyslog.com' -e $TESTDIR/$errorlog
 
 echo 'Send Message...'
-./send $TLSLIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'server.testbench.rsyslog.com' --errorfile $TESTDIR/$errorlog $OPT_VERBOSE
+./send $TLSLIB -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ca.pem -y ${srcdir}/tls-certs/cert.pem -z ${srcdir}/tls-certs/key.pem -P 'server.testbench.rsyslog.com' -e $TESTDIR/$errorlog $OPT_VERBOSE
 
 stop_receiver
 # Perform multiline GREP with -z


### PR DESCRIPTION
- removed long options from receive send utilities (Not supported on AIX).
- added checks for existing commands in some tests.
- added msleep utility from rsyslog (sleep, timeout etc. not supported on AIX).

closes: https://github.com/rsyslog/librelp/issues/228