### PR TITLE
gnutls: Fix relpTcpRcv error handler, should return error now.

### DIFF
--- a/tests/basic-sessionbreak-vg.sh
+++ b/tests/basic-sessionbreak-vg.sh
@@ -18,7 +18,7 @@ export NUMMESSAGES=100000
 export NUMLOOPS=2
 
 #export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
-export valgrind="valgrind --malloc-fill=ff --free-fill=fe --leak-check=full --log-fd=1 --error-exitcode=10 --gen-suppressions=all"
+export valgrind="valgrind --malloc-fill=ff --free-fill=fe --leak-check=full --log-fd=1 --error-exitcode=10 --gen-suppressions=all --suppressions=$srcdir/known_issues.supp"
 	
 startup_receiver_valgrind -N -e error.out.log -O $OUTFILE
 

--- a/tests/known_issues.supp
+++ b/tests/known_issues.supp
@@ -1,0 +1,21 @@
+{
+   <dlcose-missing-to-enable-debug-symbol-display_NOT_A_LEAK>
+   Memcheck:Leak
+   ...
+   fun:dlopen*
+   ...
+}
+
+{
+   <basic-sessionbreak this leak may can happen due the many session aborts.>
+   Memcheck:Leak
+   fun:calloc
+   fun:addToEpollSet
+   fun:addSessToEpoll
+   fun:relpEngineAddToSess
+   fun:handleConnectionRequest
+   fun:engineEventLoopRun
+   fun:relpEngineRun
+   fun:main
+}
+


### PR DESCRIPTION
An exit call was left from commit 6555545c4ebe9afe9259b15c176fd81eeecc93f4
which could cause unexpected results if gnutls gnutls_record_recv
returned an error.

closes: https://github.com/rsyslog/librelp/issues/230