### PR TITLE
relp session: Add API function to enable/disable Relp Client AutoRetry feature

### DIFF
--- a/.github/workflows/rsyslog.yml
+++ b/.github/workflows/rsyslog.yml
@@ -116,7 +116,8 @@ jobs:
                 --enable-imdiag \
                 --enable-omstdout \
                 --enable-relp \
-                --enable-testbench
+                --enable-testbench \
+                --enable-valgrind
           make -j
           cd tests
           make -j8 check

--- a/src/librelp.h
+++ b/src/librelp.h
@@ -245,6 +245,7 @@ relpRetVal relpCltConnect(relpClt_t *pThis, int protFamily, unsigned char *port,
 relpRetVal relpCltSendSyslog(relpClt_t *pThis, unsigned char *pMsg, size_t lenMsg);
 relpRetVal relpCltSetTimeout(relpClt_t *pThis, unsigned timeout);
 relpRetVal relpCltSetConnTimeout(relpClt_t *pThis, int connTimeout);
+relpRetVal relpCltSetAutoRetry(relpClt_t *pThis, int AutoRetry);
 relpRetVal relpCltSetWindowSize(relpClt_t *pThis, int sizeWindow);
 relpRetVal relpCltSetClientIP(relpClt_t *pThis, unsigned char *ipAddr);
 relpRetVal relpCltEnableTLS(relpClt_t *pThis);

--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -121,6 +121,7 @@ relpCltConnect(relpClt_t *const pThis, int protFamily, unsigned char *port, unsi
 	CHKRet(relpSessConstruct(&pThis->pSess, pThis->pEngine, RELP_CLT_CONN, pThis, pThis->pUsr));
 	CHKRet(relpSessSetTimeout(pThis->pSess, pThis->timeout));
 	CHKRet(relpSessSetConnTimeout(pThis->pSess, pThis->connTimeout));
+	CHKRet(relpSessSetAutoRetry(pThis->pSess, pThis->bAutoRetry));
 	CHKRet(relpSessSetWindowSize(pThis->pSess, pThis->sizeWindow));
 	CHKRet(relpSessSetClientIP(pThis->pSess, pThis->clientIP));
 	if(pThis->bEnableTLS) {
@@ -165,6 +166,19 @@ relpCltReconnect(relpClt_t *const pThis)
 	CHKRet(relpSessTryReestablish(pThis->pSess));
 
 finalize_it:
+	LEAVE_RELPFUNC;
+}
+
+
+/** Enable / Disable AutoRetry Mode for this client. Value 0 means disabled, value 1
+ * means enabled.
+ */
+relpRetVal PART_OF_API
+relpCltSetAutoRetry(relpClt_t *const pThis, int AutoRetry)
+{
+	ENTER_RELPFUNC;
+	RELPOBJ_assert(pThis, Clt);
+	pThis->bAutoRetry = (AutoRetry == 0 ? 0 : 1);
 	LEAVE_RELPFUNC;
 }
 

--- a/src/relpclt.h
+++ b/src/relpclt.h
@@ -43,6 +43,7 @@ struct relpClt_s {
 	void *pUsr;		/**< user pointer (opaque data) */
 	int bEnableTLS;		/**< is TLS to be used? */
 	int bEnableTLSZip;	/**< is compression to be used together with TLS? */
+	int bAutoRetry;		/**< automatically try (once) to reestablish a broken session? */
 	int sizeWindow;		/**< size of our app-level communications window */
 	char *pristring;	/**< priority string for GnuTLS */
 	relpAuthMode_t authmode;

--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -980,6 +980,14 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
+relpRetVal
+relpSessSetAutoRetry(relpSess_t *const pThis, int AutoRetry)
+{
+	ENTER_RELPFUNC;
+	RELPOBJ_assert(pThis, Sess);
+	pThis->bAutoRetry = (AutoRetry == 0 ? 0 : 1);
+	LEAVE_RELPFUNC;
+}
 
 relpRetVal
 relpSessSetWindowSize(relpSess_t *const pThis, int sizeWindow)

--- a/src/relpsess.h
+++ b/src/relpsess.h
@@ -149,6 +149,7 @@ relpRetVal relpSessTryReestablish(relpSess_t *pThis);
 relpRetVal relpSessSetProtocolVersion(relpSess_t *pThis, int protocolVersion);
 relpRetVal relpSessSetTimeout(relpSess_t *pThis, unsigned timeout);
 relpRetVal relpSessSetConnTimeout(relpSess_t *pThis, int connTimeout);
+relpRetVal relpSessSetAutoRetry(relpSess_t *pThis, int AutoRetry);
 relpRetVal relpSessSetWindowSize(relpSess_t *pThis, int sizeWindow);
 relpRetVal relpSessSetClientIP(relpSess_t *pThis, unsigned char *ip);
 relpRetVal relpSessEnableTLS(relpSess_t *pThis);


### PR DESCRIPTION
The feature controls if a relp session can automatically be
reestablished automatically. Tests are difficult to make in librelp
testbench, so it makes more sense to create them in rsyslog
in a later step.

closes: https://github.com/rsyslog/librelp/issues/223