### PR TITLE
Fix warnings reported by covscan

### DIFF
--- a/src/offers.c
+++ b/src/offers.c
@@ -216,6 +216,7 @@ relpOfferValueAdd(unsigned char *pszVal, int intVal, relpOffer_t *pOffer)
 	/* check which value we need to use */
 	if(pszVal == NULL) {
 		snprintf((char*)pThis->szVal, sizeof(pThis->szVal), "%d", intVal);
+		pThis->szVal[RELP_MAX_OFFER_FEATUREVALUE] = '\0';
 		pThis->intVal = intVal;
 	} else {
 		strncpy((char*)pThis->szVal, (char*)pszVal, sizeof(pThis->szVal) - 1);
@@ -264,6 +265,7 @@ relpOfferAdd(relpOffer_t **ppThis, unsigned char *pszName, relpOffers_t *pOffers
 
 	CHKRet(relpOfferConstruct(&pThis, pOffers->pEngine));
 	strncpy((char*)pThis->szName, (char*)pszName, sizeof(pThis->szName));
+	pThis->szName[RELP_MAX_OFFER_FEATURENAME] = '\0';
 	pThis->pNext = pOffers->pRoot;
 	pOffers->pRoot = pThis;
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1595,7 +1595,7 @@ relpTcpRtryHandshake_ossl(relpTcp_t *const pThis)
 				relpTcpLastSSLErrorMsg(res, pThis, "relpTcpRtryHandshake Server");
 				ABORT_FINALIZE(RELP_RET_ERR_TLS_SETUP);
 			} else {
-				snprintf(errmsg, sizeof(errmsg), 
+				snprintf(errmsg, sizeof(errmsg),
 				"relpTcpRtryHandshake_ossl: Server handshake failed with %d - Aborting handshake.",
 					resErr);
 				callOnErr(pThis, errmsg, RELP_RET_ERR_TLS_SETUP);
@@ -1624,7 +1624,7 @@ relpTcpRtryHandshake_ossl(relpTcp_t *const pThis)
 				relpTcpLastSSLErrorMsg(res, pThis, "relpTcpRtryHandshake Client");
 				ABORT_FINALIZE(RELP_RET_ERR_TLS_SETUP /*RS_RET_RETRY*/);
 			} else {
-				snprintf(errmsg, sizeof(errmsg), 
+				snprintf(errmsg, sizeof(errmsg),
 				"relpTcpRtryHandshake_ossl: Client handshake failed with %d - Aborting handshake.",
 					resErr);
 				callOnErr(pThis, errmsg, RELP_RET_ERR_TLS_SETUP);
@@ -1762,7 +1762,7 @@ relpTcpAcceptConnReqInitTLS_ossl(relpTcp_t *const pThis, relpSrv_t *const pSrv)
 
 	// Set SSL_MODE_AUTO_RETRY to SSL obj
 	SSL_set_mode(pThis->ssl, SSL_MODE_AUTO_RETRY);
-	
+
 	// Copy Properties from Server TCP obj over
 	pThis->authmode = pSrv->pTcp->authmode;
 	pThis->pUsr = pSrv->pUsr;
@@ -2471,6 +2471,7 @@ GenFingerprintStr(const char *pFingerprint,const int sizeFingerprint,
 		for(iSrc = 0; iSrc < sizeFingerprint ; ++iSrc, iDst += 3) {
 			sprintf(fpBuf+iDst, ":%2.2X", (unsigned char) pFingerprint[iSrc]);
 		}
+		fpBuf[sizeTotal] = '\0';
 	}else if(bufLen>=1){
 		if (pEngine!=NULL)
 			pEngine->dbgprint((char*)"warn: buffer overflow for %s signature\n",digestType);


### PR DESCRIPTION
I've executed covscan analysis on the librelp component, which detected a list of potential defects. I was able to fix most of them but the 3rd warning seems like a false positive to me. Let me know if there is a way to make such a warning disappear.

### Error: BUFFER_SIZE (CWE-170): [#def1]
```
librelp-1.9.0/src/offers.c:221: buffer_size_warning: Calling "strncpy" with a maximum size argument of 256 bytes on destination array "pThis->szVal" of size 256 bytes might leave the destination string unterminated.
#  219|   		pThis->intVal = intVal;
#  220|   	} else {
#  221|-> 		strncpy((char*)pThis->szVal, (char*)pszVal, sizeof(pThis->szVal));
#  222|   		/* check if the string actually is an integer... */
#  223|   		Val = 0;
```

### Error: BUFFER_SIZE (CWE-170): [#def2]
```
librelp-1.9.0/src/offers.c:266: buffer_size_warning: Calling "strncpy" with a maximum size argument of 33 bytes on destination array "pThis->szName" of size 33 bytes might leave the destination string unterminated.
#  264|   
#  265|   	CHKRet(relpOfferConstruct(&pThis, pOffers->pEngine));
#  266|-> 	strncpy((char*)pThis->szName, (char*)pszName, sizeof(pThis->szName));
#  267|   	pThis->pNext = pOffers->pRoot;
#  268|   	pOffers->pRoot = pThis;
```

### Error: RESOURCE_LEAK (CWE-772): [#def3]
```
librelp-1.9.0/src/relpsrv.c:409: alloc_arg: "relpTcpConstruct" allocates memory that is stored into "pTcp".
librelp-1.9.0/src/relpsrv.c:410: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetUsrPtr".
librelp-1.9.0/src/relpsrv.c:412: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpEnableTLS".
librelp-1.9.0/src/relpsrv.c:414: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpEnableTLSZip".
librelp-1.9.0/src/relpsrv.c:416: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetDHBits".
librelp-1.9.0/src/relpsrv.c:417: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetGnuTLSPriString".
librelp-1.9.0/src/relpsrv.c:418: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetTlsConfigCmd".
librelp-1.9.0/src/relpsrv.c:419: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetAuthMode".
librelp-1.9.0/src/relpsrv.c:420: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetCACert".
librelp-1.9.0/src/relpsrv.c:421: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetOwnCert".
librelp-1.9.0/src/relpsrv.c:422: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetPrivKey".
librelp-1.9.0/src/relpsrv.c:423: noescape: Resource "pTcp" is not freed or pointed-to in "relpTcpSetPermittedPeers".
librelp-1.9.0/src/relpsrv.c:438: leaked_storage: Variable "pTcp" going out of scope leaks the storage it points to.
#  436|   	}
#  437|   
#  438|-> 	LEAVE_RELPFUNC;
#  439|   }
```

### Error: BUFFER_SIZE (CWE-120): [#def4]
```
librelp-1.9.0/src/tcp.c:2384: buffer_size: Calling "strncpy" with a source string whose length (4 chars) is greater than or equal to the size argument (4) will fail to null-terminate "fpBuf".
# 2382|   	if (sizeTotal <bufLen)
# 2383|   	{
# 2384|-> 		strncpy(fpBuf,digestType,sizeDigest);
# 2385|   		iDst=sizeDigest;
# 2386|   		for(iSrc = 0; iSrc < sizeFingerprint ; ++iSrc, iDst += 3) {
```