### PR TITLE
librelp hardening: Fix multiple minor issues causing debugging trouble

### DIFF
--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -168,7 +168,6 @@ relpSessDestruct(relpSess_t **ppThis)
 	assert(ppThis != NULL);
 	pThis = *ppThis;
 	RELPOBJ_assert(pThis, Sess);
-pThis->pEngine->dbgprint((char*)"relpSessDestruct 1\n");
 
 	/* pTcp may be NULL if we run into the destructor due to an error that occured
 	 * during construction.
@@ -187,15 +186,11 @@ pThis->pEngine->dbgprint((char*)"relpSessDestruct 1\n");
 			}
 		}
 	}
-pThis->pEngine->dbgprint((char*)"relpSessDestruct 2\n");
 
 	if(pThis->pSendq != NULL)
 		relpSendqDestruct(&pThis->pSendq);
-pThis->pEngine->dbgprint((char*)"relpSessDestruct 3\n");
 	if(pThis->pTcp != NULL)
 		relpTcpDestruct(&pThis->pTcp);
-pThis->pEngine->dbgprint((char*)"relpSessDestruct 4\n");
-
 
 	/* unacked list */
 	for(pUnacked = pThis->pUnackedLstRoot ; pUnacked != NULL ; ) {
@@ -204,7 +199,6 @@ pThis->pEngine->dbgprint((char*)"relpSessDestruct 4\n");
 		relpSendbufDestruct(&pUnackedToDel->pSendbuf);
 		free(pUnackedToDel);
 	}
-pThis->pEngine->dbgprint((char*)"relpSessDestruct 5\n");
 
 	if(pThis->pCurrRcvFrame != NULL)
 		relpFrameDestruct(&pThis->pCurrRcvFrame);
@@ -268,20 +262,16 @@ finalize_it:
 relpRetVal
 relpSessRcvData(relpSess_t *const pThis)
 {
-	// relpOctet_t rcvBuf[RELP_RCV_BUF_SIZE+1];
-	relpOctet_t* pRcvBuf = NULL;
+	relpOctet_t rcvBuf[RELP_RCV_BUF_SIZE+1];
 	ssize_t lenBuf;
 	ssize_t i;
 
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Sess);
 
-	if((pRcvBuf = malloc( (RELP_RCV_BUF_SIZE+1) * sizeof(relpOctet_t))) == NULL)
-		ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
-
 	lenBuf = RELP_RCV_BUF_SIZE;
-	pRcvBuf[lenBuf] = '\0';
-	CHKRet(relpTcpRcv(pThis->pTcp, pRcvBuf, &lenBuf));
+	rcvBuf[lenBuf] = '\0';
+	CHKRet(relpTcpRcv(pThis->pTcp, rcvBuf, &lenBuf));
 
 	if(lenBuf == 0) {
 		callOnErr(pThis, (char*) "server closed relp session, session broken", RELP_RET_SESSION_BROKEN);
@@ -305,8 +295,8 @@ relpSessRcvData(relpSess_t *const pThis)
 		}
 	} else {
 		/* Terminate buffer and output received data to debug*/
-		pRcvBuf[lenBuf] = '\0';
-		pThis->pEngine->dbgprint((char*)"relp session read %d octets, buf '%s'\n", (int) lenBuf, pRcvBuf);
+		rcvBuf[lenBuf] = '\0';
+		pThis->pEngine->dbgprint((char*)"relp session read %d octets, buf '%s'\n", (int) lenBuf, rcvBuf);
 
 		/* we have regular data, which we now can process */
 		for(i = 0 ; i < lenBuf ; ++i) {
@@ -315,13 +305,11 @@ relpSessRcvData(relpSess_t *const pThis)
 					"breaking session %p\n", (void*) pThis);
 				ABORT_FINALIZE(RELP_RET_SESSION_BROKEN);
 			}
-			CHKRet(relpFrameProcessOctetRcvd(&pThis->pCurrRcvFrame, pRcvBuf[i], pThis));
+			CHKRet(relpFrameProcessOctetRcvd(&pThis->pCurrRcvFrame, rcvBuf[i], pThis));
 		}
 	}
 
 finalize_it:
-	if (pRcvBuf != NULL)
-		free(pRcvBuf);
 	LEAVE_RELPFUNC;
 }
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -791,35 +791,40 @@ relpTcpDestruct(relpTcp_t **ppThis)
 	ENTER_RELPFUNC;
 	assert(ppThis != NULL);
 	pThis = *ppThis;
-	RELPOBJ_assert(pThis, Tcp);
+	/* AVOID freeing pThis AGAIN! */
+	if (pThis != NULL) {
+		RELPOBJ_assert(pThis, Tcp);
+		// Only DEBUG if pThis  is available
+		pThis->pEngine->dbgprint((char*)"relpTcpDestruct for %p\n", pThis);
 
-	if(pThis->sock != -1) {
-		shutdown(pThis->sock, SHUT_RDWR);
-		close(pThis->sock);
-		pThis->sock = -1;
-	}
-
-	if(pThis->socks != NULL) {
-		/* if we have some sockets at this stage, we need to close them */
-		for(int i = 1 ; i <= pThis->socks[0] ; ++i) {
-			shutdown(pThis->socks[i], SHUT_RDWR);
-			close(pThis->socks[i]);
+		if(pThis->sock != -1) {
+			shutdown(pThis->sock, SHUT_RDWR);
+			close(pThis->sock);
+			pThis->sock = -1;
 		}
-		free(pThis->socks);
+
+		if(pThis->socks != NULL) {
+			/* if we have some sockets at this stage, we need to close them */
+			for(int i = 1 ; i <= pThis->socks[0] ; ++i) {
+				shutdown(pThis->socks[i], SHUT_RDWR);
+				close(pThis->socks[i]);
+			}
+			free(pThis->socks);
+		}
+		relpTcpDestructTLS(pThis);
+
+		free(pThis->pRemHostIP);
+		free(pThis->pRemHostName);
+		free(pThis->pristring);
+		free(pThis->caCertFile);
+		free(pThis->ownCertFile);
+		free(pThis->privKeyFile);
+		free(pThis->tlsConfigCmd);
+
+		/* done with de-init work, now free tcp object itself */
+		free(pThis);
+		*ppThis = NULL;
 	}
-	relpTcpDestructTLS(pThis);
-
-	free(pThis->pRemHostIP);
-	free(pThis->pRemHostName);
-	free(pThis->pristring);
-	free(pThis->caCertFile);
-	free(pThis->ownCertFile);
-	free(pThis->privKeyFile);
-	free(pThis->tlsConfigCmd);
-
-	/* done with de-init work, now free tcp object itself */
-	free(pThis);
-	*ppThis = NULL;
 
 	LEAVE_RELPFUNC;
 }
@@ -3209,15 +3214,18 @@ relpTcpRcv(relpTcp_t *const pThis, relpOctet_t *const pRcvBuf, ssize_t *const pL
 			if(errno == EAGAIN) {
 				// Set mode to Retry
 				pThis->rtryOp = relpTCP_RETRY_recv;
+			} else if(errno == ECONNRESET) {
+				pThis->pEngine->dbgprint((char*)"relpTcpRcv: read failed with errno ECONNRESET!\n");
+			} else if(errno == 0) {
+				pThis->pEngine->dbgprint((char*)"relpTcpRcv: read failed BUT errno == 0!\n");
 			} else {
-				pThis->pEngine->dbgprint((char*)"relpTcpRcv: read failed errno=%d\n", errno);
+				pThis->pEngine->dbgprint((char*)"relpTcpRcv: read failed errno='%d'\n", errno);
 			}
 		}
-
 	}
 
-	pThis->pEngine->dbgprint((char*)"relpTcpRcv return. relptcp [%p], iRet %d, lenRcvd %d, pLenBuf %zd\n",
-		(void *) pThis, iRet, lenRcvd, *pLenBuf);
+	pThis->pEngine->dbgprint((char*)"relpTcpRcv return. relptcp [%p], iRet %d, max %d, lenRcvd %d, pLenBuf %zd\n",
+		(void *) pThis, iRet, RELP_RCV_BUF_SIZE, lenRcvd, *pLenBuf);
 	LEAVE_RELPFUNC;
 }
 
@@ -3363,7 +3371,7 @@ relpTcpSend(relpTcp_t *const pThis, relpOctet_t *const pBuf, ssize_t *const pLen
 			CHKRet(relpTcpSend_ossl(pThis, pBuf, pLenBuf));
 		}
 	} else {
-		pThis->pEngine->dbgprint((char*)"relpTcpSend: send data: %.*s\n", (int) *pLenBuf, pBuf);
+		pThis->pEngine->dbgprint((char*)"relpTcpSend: send data: '%.*s'\n", (int) *pLenBuf, pBuf);
 		written = send(pThis->sock, pBuf, *pLenBuf, 0);
 		const int errno_save = errno;
 		pThis->pEngine->dbgprint((char*)"relpTcpSend: sock %d, lenbuf %zd, send returned %d [errno %d]\n",
@@ -3541,9 +3549,10 @@ static relpRetVal LIBRELP_ATTR_NONNULL()
 relpTcpConnectTLSInit(NOTLS_UNUSED relpTcp_t *const pThis)
 {
 	ENTER_RELPFUNC;
-pThis->pEngine->dbgprint((char*)"relpTcpConnectTLSInit: lib: %d\n", pThis->pEngine->tls_lib);
 	#if  defined(WITH_TLS)
 	if(pThis->bEnableTLS) {
+		// Only DEBUG this if TLS enabled!
+		pThis->pEngine->dbgprint((char*)"relpTcpConnectTLSInit: lib: %d\n", pThis->pEngine->tls_lib);
 		if(pThis->pEngine->tls_lib == 0) {
 			CHKRet(relpTcpConnectTLSInit_gtls(pThis));
 		} else {

--- a/tests/receiver-abort.sh
+++ b/tests/receiver-abort.sh
@@ -5,11 +5,11 @@
 . ${srcdir:=$(pwd)}/test-framework.sh
 # export OPT_VERBOSE=-v # uncomment for debugging 
 export errorlog="error.$LIBRELP_DYN.log"
-export NUMMESSAGES=100000
+export NUMMESSAGES=10000
 check_command_available timeout
 
 startup_receiver -e ${TESTDIR}/${errorlog}
-./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES -N -K 20000 -I $RECEIVE_PID $OPT_VERBOSE &
+./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES -N -K 2000 -I $RECEIVE_PID $OPT_VERBOSE &
 SENDER_PID=$!
 
 for i in {1..3};  do

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -9,7 +9,7 @@ export LIBRELP_DYN="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head --bytes 4)"
 export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
 # **** use the line below for very hard to find leaks! *****
 # export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1 --leak-check=full --show-leak-kinds=all"
-export OPT_VERBOSE=-v # uncomment for debugging 
+# export OPT_VERBOSE=-v # uncomment for debugging 
 source set-envvars
 
 ######################################################################

--- a/tests/test-framework.sh
+++ b/tests/test-framework.sh
@@ -8,8 +8,8 @@ TB_TIMEOUT_STARTUP=400  # 40 seconds - Solaris sometimes needs this...
 export LIBRELP_DYN="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head --bytes 4)"
 export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
 # **** use the line below for very hard to find leaks! *****
-#export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1 --leak-check=full --show-leak-kinds=all"
-#export OPT_VERBOSE=-v # uncomment for debugging 
+# export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1 --leak-check=full --show-leak-kinds=all"
+export OPT_VERBOSE=-v # uncomment for debugging 
 source set-envvars
 
 ######################################################################

--- a/tests/tls-basic-realistic.sh
+++ b/tests/tls-basic-realistic.sh
@@ -3,7 +3,7 @@
 # a more relastic test which actually sends a bit larger number
 # of messages
 . ${srcdir:=$(pwd)}/test-framework.sh
-NUMMESSAGES=50000
+NUMMESSAGES=10000
 
 function actual_test() {
 	startup_receiver -l $TEST_TLS_LIB -T -a "name" -x ${srcdir}/tls-certs/ca.pem \

--- a/tests/tls-receiver-abort.sh
+++ b/tests/tls-receiver-abort.sh
@@ -4,12 +4,12 @@
 # of messages
 . ${srcdir:=$(pwd)}/test-framework.sh
 check_command_available timeout
-export NUMMESSAGES=100000
+export NUMMESSAGES=10000
 
 actual_test() {
 	startup_receiver
 	./send -t 127.0.0.1 -p $TESTPORT -n$NUMMESSAGES -N \
-		-K 20000 -I$RECEIVE_PID $OPT_VERBOSE &
+		-K 2000 -I$RECEIVE_PID $OPT_VERBOSE &
 	SENDER_PID=$!
 
 	for i in {1..3};  do


### PR DESCRIPTION
- avoid invalid dbgprint calls
- avoid double free in relpTcpDestruct (if called twice).
- add debug output into relpTcpRcv
- move receive buffer in relpSessRcvData to dyn memory (Stack before)
- AIX: in relpTcpRcv we need to set RETRY_recv if errno is 0