### PR TITLE
code cleanup

### DIFF
--- a/src/relpsess.c
+++ b/src/relpsess.c
@@ -682,11 +682,6 @@ relpSessSendCommand(relpSess_t *const pThis, unsigned char *pCmd, size_t lenCmd,
 	CHKRet(relpSessWaitState(pThis, eRelpSessState_READY_TO_SEND,
 		pThis->timeout));
 
-	/* re-try once if automatic retry mode is set */
-	if(pThis->bAutoRetry && pThis->sessState == eRelpSessState_BROKEN) {
-		CHKRet(relpSessTryReestablish(pThis));
-	}
-
 	/* then send our data */
 	if(pThis->sessState == eRelpSessState_BROKEN)
 		ABORT_FINALIZE(RELP_RET_SESSION_BROKEN);

--- a/src/relpsess.h
+++ b/src/relpsess.h
@@ -105,7 +105,6 @@ struct relpSess_s {
 	struct relpSendq_s *pSendq; /**< our send queue */
 
 	/* properties needed for client operation */
-	int bAutoRetry;	/**< automatically try (once) to reestablish a broken session? */
 	int sizeWindow;	/**< size of our app-level communications window */
 	unsigned timeout; /**< timeout after which session is to be considered broken */
 	int connTimeout; /**< connection timeout */


### PR DESCRIPTION
During the initial librelp implementation it was thought about an auto-retry feature (whatever that means). Variable bAutoRetry was created to control that behaviour. It's default was 0 (inactive). Some code has been written to evaluate that variable and act accordingly. However, no setter method for this variable was created and it was also nowhere changed from the default value of zero. As such, the code activated by it was never used.

This patch now removes both the variable and the few code lines accessing it. This will have no effect, as the code was never used.

closes: https://github.com/rsyslog/librelp/issues/223
replaces: https://github.com/rsyslog/librelp/pull/234