### PR TITLE
typo fix

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -2352,7 +2352,7 @@ relpTcpAddToCertNamesBuffer(relpTcp_t *const pThis,
 		"DNSname: %s; ", certName);
 	if(n < 0 || n >= (int) (buflen - currIdx)) {
 		callOnAuthErr(pThis, "", "certificate validation failed, names "
-			"inside certifcate are way too long (> 32KiB)",
+			"inside certificate are way too long (> 32KiB)",
 			RELP_RET_AUTH_CERT_INVL);
 		r = RELP_RET_PARAM_ERROR;
 	} else {

--- a/tests/tls-basic-brokencert.sh
+++ b/tests/tls-basic-brokencert.sh
@@ -9,5 +9,5 @@ echo 'Send Message...'
 ./send -t 127.0.0.1 -p $TESTPORT -m "testmessage" -T -a "name" -x ${srcdir}/tls-certs/ossl-ca.pem -y ${srcdir}/tls-certs/ossl-clientbrok-cert.pem -z ${srcdir}/tls-certs/ossl-clientbrok-key.pem -P 'server.testbench.rsyslog.com' -e error.out.log $OPT_VERBOSE 1>>${OUTFILE} 2>&1
 
 stop_receiver
-check_output "certificate validation failed, names inside certifcate are way to long" error.out.log
+check_output "certificate validation failed, names inside certificate are way to long" error.out.log
 terminate


### PR DESCRIPTION
Spotted by lintian:

I: librelp0: spelling-error-in-binary certifcate certificate [usr/lib/x86_64-linux-gnu/librelp.so.0.5.1]