### PR TITLE
CI: upgrading to newer ubuntu version as required by github

### DIFF
--- a/.github/workflows/run_centos_8.yml
+++ b/.github/workflows/run_centos_8.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   check_run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 50
 
     steps:

--- a/.github/workflows/run_fedora_36.yml
+++ b/.github/workflows/run_fedora_36.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   check_run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 50
 
     steps:


### PR DESCRIPTION
we used older ubuntu versions as base for our containers, these versions are no longer available in github actions. As such, we upgraded. Has no effect on testbench as we execute everything in container environment and container remains the same.