### PR TITLE
tests: Fix callback prototype

### DIFF
--- a/tests/receive.c
+++ b/tests/receive.c
@@ -68,7 +68,7 @@ doSleep(int iSeconds, const int iuSeconds)
 }
 
 static void
-hdlr_enable(int sig, void (*hdlr)())
+hdlr_enable(int sig, void (*hdlr)(const int))
 {
 	struct sigaction sigAct;
 	memset(&sigAct, 0, sizeof (sigAct));

--- a/tests/send.c
+++ b/tests/send.c
@@ -57,7 +57,7 @@ struct usrdata { /* used for testing user pointer pass-back */
 struct usrdata *userdata = NULL;
 
 static void
-hdlr_enable(int sig, void (*hdlr)())
+hdlr_enable(int sig, void (*hdlr)(const int))
 {
 	struct sigaction sigAct;
 	memset(&sigAct, 0, sizeof (sigAct));


### PR DESCRIPTION
clang errors about it

| ../../git/tests/receive.c:71:34: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
|    71 | hdlr_enable(int sig, void (*hdlr)())
|       |                                  ^
|       |                                   void
| 1 error generated.