### PR TITLE
relp: fix build against upcoming `gcc-14` (`-Werror=calloc-transposed…

### DIFF
--- a/src/relp.c
+++ b/src/relp.c
@@ -98,7 +98,7 @@ addToEpollSet(relpEngine_t *const pThis, epolld_type_t typ, void *ptr, int sock,
 	epolld_t *epd = NULL;
 	ENTER_RELPFUNC;
 
-	CHKmalloc(epd = calloc(sizeof(epolld_t), 1));
+	CHKmalloc(epd = calloc(1, sizeof(epolld_t)));
 	epd->typ = typ;
 	epd->ptr = ptr;
 	epd->sock = sock;


### PR DESCRIPTION
…-args`)

`gcc-14` added a new `-Wcalloc-transposed-args` warning recently. It
   detected minor infelicity in `calloc()` API usage

Fixes
../../git/src/relp.c: In function 'addToEpollSet': ../../git/src/relp.c:101:39: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  101 |         CHKmalloc(epd = calloc(sizeof(epolld_t), 1));
      |                                       ^~~~~~~~