### PR TITLE
Minute sample app mods

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,0 +1,10 @@
+LDFLAGS += -lrelp
+
+SAMPLE_PROGRAMS = \
+    sample_client \
+    sample_server
+
+all: $(SAMPLE_PROGRAMS)
+
+clean:
+	rm -f $(SAMPLE_PROGRAMS)

--- a/example/sample_client.c
+++ b/example/sample_client.c
@@ -17,6 +17,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <string.h>
 #include "librelp.h"
 

--- a/example/sample_client.c
+++ b/example/sample_client.c
@@ -34,7 +34,7 @@ dbgprintf(char *fmt, ...)
 	va_start(ap, fmt);
 	vsnprintf(pszWriteBuf, sizeof(pszWriteBuf), fmt, ap);
 	va_end(ap);
-	printf("send.c: %s", pszWriteBuf);
+	fprintf(stderr, "receive.c: %s", pszWriteBuf);
 }
 
 void print_usage()

--- a/example/sample_server.c
+++ b/example/sample_server.c
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <string.h>
 #include "librelp.h"
 

--- a/example/sample_server.c
+++ b/example/sample_server.c
@@ -35,7 +35,7 @@ dbgprintf(char *fmt, ...)
 	va_start(ap, fmt);
 	vsnprintf(pszWriteBuf, sizeof(pszWriteBuf), fmt, ap);
 	va_end(ap);
-	printf("receive.c: %s", pszWriteBuf);
+	fprintf(stderr, "receive.c: %s", pszWriteBuf);
 }
 
 static relpRetVal onSyslogRcv(unsigned char *pHostname, unsigned char *pIP, unsigned char *msg, size_t lenMsg) {


### PR DESCRIPTION
- Added basic makefile (esp geared to those not building `librelp` and just kicking the tires on a prebuilt version without engaging the full `rsyslog`.
- Added header (`stdarg.h`) that prevented building on  my FC40
- Direct  `dbgprintf` logs to stderr, user can redirect to /dev/null if they just want to observe payload.