### PR TITLE
Use void prototype for print_usage in sample client

### DIFF
--- a/example/sample_client.c
+++ b/example/sample_client.c
@@ -36,7 +36,7 @@ dbgprintf(char *fmt, ...)
 	printf("send.c: %s", pszWriteBuf);
 }
 
-void print_usage()
+static void print_usage(void)
 {
 	printf("Usage: send SERVER PORTNUM MESSAGE\n");
 }


### PR DESCRIPTION
## Summary
- Mark `print_usage` as `static` and define it with a `void` parameter list to indicate no arguments in `example/sample_client.c`.

## Testing
- `gcc -c example/sample_client.c -I./src` *(fails: implicit declaration of va_start/va_end — header dependency missing but compilation continued)*
- `make check` *(fails: No rule to make target 'check')*
- `autoreconf -i` *(fails: Can't exec "aclocal": No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8d1f19c88332a08547edb630d5ea