### PR TITLE
Make sample server usage helper static

### DIFF
--- a/example/sample_server.c
+++ b/example/sample_server.c
@@ -53,9 +53,9 @@ static relpRetVal onSyslogRcv(unsigned char *pHostname, unsigned char *pIP, unsi
 	return RELP_RET_OK;
 }
 
-void print_usage()
+static void print_usage(void)
 {
-	printf("Usage: receive PORTNUM\n");
+        printf("Usage: receive PORTNUM\n");
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
## Summary
- Make sample_server.c's usage helper `static void print_usage(void)` to avoid implicit int return and limit visibility.

## Testing
- `make -j$(nproc)`
- `make check` *(fails: interrupted; partial tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8d293cc483329742417da614cca3