### PR TITLE
CI: force fedora 42 build with -Werror

### DIFF
--- a/.github/workflows/run_fedora_42.yml
+++ b/.github/workflows/run_fedora_42.yml
@@ -41,7 +41,7 @@ jobs:
           chmod -R go+rw .
           export RSYSLOG_CONTAINER_UID="" # use default
           #export RSYSLOG_STATSURL='http://build.rsyslog.com/testbench-failedtest.php'
-          export CFLAGS='-g'
+          export CFLAGS='-g -Werror'
           export CC='gcc'
           export USE_AUTO_DEBUG='off'
           export CI_MAKE_OPT='-j20'

--- a/devtools/run-configure.sh
+++ b/devtools/run-configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 printf "running configure with\nCC:\t$CC\nCFLAGS:\t$CFLAGS\n"
 autoreconf -fvi
-./configure $PROJ_CONFIGURE_OPTIONS
+CFLAGS="-g" ./configure $PROJ_CONFIGURE_OPTIONS


### PR DESCRIPTION
in general, this should by done by configure, but as it is urgent we now do it quick-and-dirty by giving the flag explicitely.

see also: https://github.com/rsyslog/librelp/issues/267