### PR TITLE
Fix WARN_CFLAGS sed filtering

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,7 @@ then
 			# -Wdeclaration-after-statement in gcc always generates a warning,
 			# even in c99 mode. So we need to unset it.
 			# rgerhards, 2018-05-09
-			WARN_CFLAGS="$(echo "$WARN_CFLAGS" | sed s/-Wno-error=/-W/g | sed s/-W.*declaration-after-statement//g)"
+                        WARN_CFLAGS="$(echo "$WARN_CFLAGS" | sed -e 's/-Wno-error=/-W/g' -e 's/ -Wdeclaration-after-statement//')"
 		], [
 			AM_CFLAGS="$CFLAGS -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g"
 			AC_MSG_WARN([missing AX_COMPILER_FLAGS macro, not using it])


### PR DESCRIPTION
## Summary
- ensure sed only drops `-Wdeclaration-after-statement` and converts `-Wno-error=` flags to `-W`

## Testing
- `autoreconf -fi`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68bb02b2d2508332bf27d7ae94273134