### PR TITLE
Ensure CFLAGS are used for librelp build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,8 +45,8 @@ librelp_la_SOURCES = \
 	cserverclose.c \
 	dbllinklist.h \
 	cmdif.h \
-	compat/strndup.c
-librelp_la_CPPFLAGS = $(AM_CLFAGS) $(PTHREADS_CFLAGS) $(GNUTLS_CFLAGS) $(OPENSSL_CFLAGS) $(WARN_CFLAGS)
+compat/strndup.c
+librelp_la_CFLAGS = $(AM_CFLAGS) $(PTHREADS_CFLAGS) $(GNUTLS_CFLAGS) $(OPENSSL_CFLAGS) $(WARN_CFLAGS)
 librelp_la_LIBADD = $(rt_libs) $(GNUTLS_LIBS) $(OPENSSL_LIBS)
 # info on version-info:
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html


### PR DESCRIPTION
## Summary
- Use per-target CFLAGS for librelp library so warning and error flags propagate correctly.

## Testing
- `autoreconf -fi`
- `./configure`
- `make V=1`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68bb02b5b9c08332b0f19397cb093c58