### PR TITLE
Add callback exposing client source port

### DIFF
--- a/src/librelp.h
+++ b/src/librelp.h
@@ -3,7 +3,7 @@
  * This file is meant to be included by applications using the relp library.
  * For relp library files themselves, include "relp.h".
  *
- * Copyright 2008-2018 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2025 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -207,9 +207,11 @@ relpRetVal relpEngineRun(relpEngine_t *pThis);
 relpRetVal relpEngineCltDestruct(relpEngine_t *pThis, relpClt_t **ppClt);
 relpRetVal relpEngineCltConstruct(relpEngine_t *pThis, relpClt_t **ppClt);
 relpRetVal relpEngineSetSyslogRcv(relpEngine_t *pThis,
-				  relpRetVal (*pCB)(unsigned char*, unsigned char*, unsigned char*, size_t));
+                                  relpRetVal (*pCB)(unsigned char*, unsigned char*, unsigned char*, size_t));
 relpRetVal relpEngineSetSyslogRcv2(relpEngine_t *pThis,
-				  relpRetVal (*pCB)(void*, unsigned char*, unsigned char*, unsigned char*, size_t));
+                                  relpRetVal (*pCB)(void*, unsigned char*, unsigned char*, unsigned char*, size_t));
+relpRetVal relpEngineSetSyslogRcv3(relpEngine_t *pThis,
+                                  relpRetVal (*pCB)(void*, unsigned char*, unsigned char*, unsigned char*, unsigned char*, size_t));
 relpRetVal relpEngineSetEnableCmd(relpEngine_t *pThis, unsigned char *pszCmd, relpCmdEnaState_t stateCmd);
 relpRetVal relpEngineSetDnsLookupMode(relpEngine_t *pThis, int iMode);
 relpRetVal relpEngineSetOnAuthErr(relpEngine_t *pThis,

--- a/src/relp.c
+++ b/src/relp.c
@@ -1,6 +1,6 @@
 /* The RELP (reliable event logging protocol) core protocol library.
  *
- * Copyright 2008-2020 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2025 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -442,24 +442,47 @@ finalize_it:
 
 /* a dummy for callbacks not set by the caller */
 static relpRetVal relpSrvSyslogRcvDummy2(void LIBRELP_ATTR_UNUSED *pUsr,
-	unsigned char LIBRELP_ATTR_UNUSED *pHostName,
-	unsigned char LIBRELP_ATTR_UNUSED *pIP, unsigned char LIBRELP_ATTR_UNUSED *pMsg,
-	size_t LIBRELP_ATTR_UNUSED lenMsg)
+        unsigned char LIBRELP_ATTR_UNUSED *pHostName,
+        unsigned char LIBRELP_ATTR_UNUSED *pIP, unsigned char LIBRELP_ATTR_UNUSED *pMsg,
+        size_t LIBRELP_ATTR_UNUSED lenMsg)
 { return RELP_RET_NOT_IMPLEMENTED;
 }
+static relpRetVal relpSrvSyslogRcvDummy3(void LIBRELP_ATTR_UNUSED *pUsr,
+       unsigned char LIBRELP_ATTR_UNUSED *pHostName,
+       unsigned char LIBRELP_ATTR_UNUSED *pIP, unsigned char LIBRELP_ATTR_UNUSED *pPort,
+       unsigned char LIBRELP_ATTR_UNUSED *pMsg,
+       size_t LIBRELP_ATTR_UNUSED lenMsg)
+{ return RELP_RET_NOT_IMPLEMENTED; }
 /* set the syslog receive callback. If NULL is provided, it is set to the
  * not implemented dummy.
  */
 relpRetVal PART_OF_API
 relpEngineSetSyslogRcv2(relpEngine_t *const pThis, relpRetVal (*pCB)(void *, unsigned char*,
-	unsigned char*, unsigned char*, size_t))
+       unsigned char*, unsigned char*, size_t))
 {
-	ENTER_RELPFUNC;
-	RELPOBJ_assert(pThis, Engine);
+       ENTER_RELPFUNC;
+       RELPOBJ_assert(pThis, Engine);
 
-	pThis->onSyslogRcv = NULL;
-	pThis->onSyslogRcv2 = (pCB == NULL) ? relpSrvSyslogRcvDummy2 : pCB;
-	LEAVE_RELPFUNC;
+       pThis->onSyslogRcv = NULL;
+       pThis->onSyslogRcv3 = NULL;
+       pThis->onSyslogRcv2 = (pCB == NULL) ? relpSrvSyslogRcvDummy2 : pCB;
+       LEAVE_RELPFUNC;
+}
+
+/* set the syslog receive callback. If NULL is provided, it is set to the
+ * not implemented dummy.
+ */
+relpRetVal PART_OF_API
+relpEngineSetSyslogRcv3(relpEngine_t *const pThis, relpRetVal (*pCB)(void *, unsigned char*,
+       unsigned char*, unsigned char*, unsigned char*, size_t))
+{
+       ENTER_RELPFUNC;
+       RELPOBJ_assert(pThis, Engine);
+
+       pThis->onSyslogRcv = NULL;
+       pThis->onSyslogRcv2 = NULL;
+       pThis->onSyslogRcv3 = (pCB == NULL) ? relpSrvSyslogRcvDummy3 : pCB;
+       LEAVE_RELPFUNC;
 }
 
 /**
@@ -573,9 +596,10 @@ relpEngineSetSyslogRcv(relpEngine_t *const pThis, relpRetVal (*pCB)(unsigned cha
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Engine);
 
-	pThis->onSyslogRcv = (pCB == NULL) ? relpSrvSyslogRcvDummy : pCB;
-	pThis->onSyslogRcv2 = NULL;
-	LEAVE_RELPFUNC;
+       pThis->onSyslogRcv = (pCB == NULL) ? relpSrvSyslogRcvDummy : pCB;
+       pThis->onSyslogRcv2 = NULL;
+       pThis->onSyslogRcv3 = NULL;
+       LEAVE_RELPFUNC;
 }
 
 /* Deprecated, use relpEngineListnerConstruct() family of functions.

--- a/src/relp.h
+++ b/src/relp.h
@@ -1,6 +1,6 @@
 /* The RELP (reliable event logging protocol) core protocol library.
  *
- * Copyright 2008-2020 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2025 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -125,14 +125,16 @@ typedef struct relpEngSessLst_s {
  */
 struct relpEngine_s {
 	BEGIN_RELP_OBJ;
-	void (*dbgprint)(char *fmt, ...) LIBRELP_ATTR_FORMAT(printf, 1, 2);
-	relpRetVal (*onSyslogRcv)(unsigned char*pHostname, unsigned char *pIP,
-		                  unsigned char *pMsg, size_t lenMsg); /**< callback for "syslog" cmd */
-	relpRetVal (*onSyslogRcv2)(void*, unsigned char*pHostname, unsigned char *pIP,
-		                  unsigned char *pMsg, size_t lenMsg); /**< callback for "syslog" cmd */
-	void (*onAuthErr)(void*pUsr, char *authinfo, char*errmsg, relpRetVal errcode);
-	void (*onErr)(void*pUsr, char *objinfo, char*errmsg, relpRetVal errcode);
-	void (*onGenericErr)(char *objinfo, char*errmsg, relpRetVal errcode);
+        void (*dbgprint)(char *fmt, ...) LIBRELP_ATTR_FORMAT(printf, 1, 2);
+        relpRetVal (*onSyslogRcv)(unsigned char*pHostname, unsigned char *pIP,
+                                  unsigned char *pMsg, size_t lenMsg); /**< callback for "syslog" cmd */
+        relpRetVal (*onSyslogRcv2)(void*, unsigned char*pHostname, unsigned char *pIP,
+                                  unsigned char *pMsg, size_t lenMsg); /**< callback for "syslog" cmd */
+       relpRetVal (*onSyslogRcv3)(void*, unsigned char*pHostname, unsigned char *pIP,
+                                  unsigned char *pPort, unsigned char *pMsg, size_t lenMsg); /**< callback for "syslog" cmd */
+        void (*onAuthErr)(void*pUsr, char *authinfo, char*errmsg, relpRetVal errcode);
+        void (*onErr)(void*pUsr, char *objinfo, char*errmsg, relpRetVal errcode);
+        void (*onGenericErr)(char *objinfo, char*errmsg, relpRetVal errcode);
 	int protocolVersion; /**< version of the relp protocol supported by this engine */
 
 	/* Flags */

--- a/src/scsyslog.c
+++ b/src/scsyslog.c
@@ -2,7 +2,7 @@
  *
  * This command is used to transfer syslog messages.
  *
- * Copyright 2008-2018 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2025 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -63,16 +63,20 @@ BEGINcommand(S, Syslog)
 	 * return code. I assume this should at least be optionally done.
 	 * Consider implementing this. rgerhards, 2018-04-17
 	 */
-	/* only highest version callback is called */
-	if(pSess->pEngine->onSyslogRcv2 != NULL) {
-		pSess->pEngine->onSyslogRcv2(pSess->pSrv->pUsr, pSess->pTcp->pRemHostName,
-					   	    pSess->pTcp->pRemHostIP, pFrame->pData, pFrame->lenData);
-	} else if(pSess->pEngine->onSyslogRcv != NULL) {
-		pSess->pEngine->onSyslogRcv(pSess->pTcp->pRemHostName, pSess->pTcp->pRemHostIP,
-						    pFrame->pData, pFrame->lenData);
-	} else {
-		pSess->pEngine->dbgprint((char*)"error: no syslog reception callback is set, nothing done\n");
-	}
+       /* only highest version callback is called */
+       if(pSess->pEngine->onSyslogRcv3 != NULL) {
+               pSess->pEngine->onSyslogRcv3(pSess->pSrv->pUsr, pSess->pTcp->pRemHostName,
+                                               pSess->pTcp->pRemHostIP, pSess->pTcp->pRemHostPort,
+                                               pFrame->pData, pFrame->lenData);
+       } else if(pSess->pEngine->onSyslogRcv2 != NULL) {
+               pSess->pEngine->onSyslogRcv2(pSess->pSrv->pUsr, pSess->pTcp->pRemHostName,
+                                               pSess->pTcp->pRemHostIP, pFrame->pData, pFrame->lenData);
+       } else if(pSess->pEngine->onSyslogRcv != NULL) {
+               pSess->pEngine->onSyslogRcv(pSess->pTcp->pRemHostName, pSess->pTcp->pRemHostIP,
+                                               pFrame->pData, pFrame->lenData);
+       } else {
+               pSess->pEngine->dbgprint((char*)"error: no syslog reception callback is set, nothing done\n");
+       }
 
 	/* send response */
 	iRet = relpSessSendResponse(pSess, pFrame->txnr, (unsigned char*) "200 OK", 6);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1,6 +1,6 @@
 /* This implements the relp mapping onto TCP.
  *
- * Copyright 2008-2018 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2025 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -819,6 +819,7 @@ relpTcpDestruct(relpTcp_t **ppThis)
 
 		free(pThis->pRemHostIP);
 		free(pThis->pRemHostName);
+		free(pThis->pRemHostPort);
 		free(pThis->pristring);
 		free(pThis->caCertFile);
 		free(pThis->ownCertFile);
@@ -923,6 +924,7 @@ relpTcpSetRemHost(relpTcp_t *const pThis, struct sockaddr *pAddr)
 	int error;
 	unsigned char szIP[NI_MAXHOST] = "";
 	unsigned char szHname[NI_MAXHOST+64] = ""; /* 64 extra bytes for message text */
+	unsigned char szPort[NI_MAXSERV] = "";
 	struct addrinfo hints, *res;
 	size_t len;
 
@@ -931,11 +933,12 @@ relpTcpSetRemHost(relpTcp_t *const pThis, struct sockaddr *pAddr)
 	pEngine = pThis->pEngine;
 	assert(pAddr != NULL);
 
-	error = getnameinfo(pAddr, SALEN(pAddr), (char*)szIP, sizeof(szIP), NULL, 0, NI_NUMERICHOST);
-	if(error) {
+	if((error = getnameinfo(pAddr, SALEN(pAddr), (char*)szIP, sizeof(szIP), (char*)szPort,
+	            sizeof(szPort), NI_NUMERICHOST | NI_NUMERICSERV)) != 0) {
 		pThis->pEngine->dbgprint((char*)"Malformed from address %s\n", gai_strerror(error));
 		strcpy((char*)szHname, "???");
 		strcpy((char*)szIP, "???");
+		strcpy((char*)szPort, "???");
 		ABORT_FINALIZE(RELP_RET_INVALID_HNAME);
 	}
 
@@ -980,6 +983,16 @@ relpTcpSetRemHost(relpTcp_t *const pThis, struct sockaddr *pAddr)
 		ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
 	}
 	memcpy(pThis->pRemHostName, szHname, len);
+
+	len = strlen((char*)szPort) + 1; /* +1 for \0 byte */
+	if((pThis->pRemHostPort = malloc(len)) == NULL) {
+		free(pThis->pRemHostIP);
+		free(pThis->pRemHostName);
+		pThis->pRemHostIP = NULL;
+		pThis->pRemHostName = NULL;
+		ABORT_FINALIZE(RELP_RET_OUT_OF_MEMORY);
+	}
+	memcpy(pThis->pRemHostPort, szPort, len);
 
 finalize_it:
 	LEAVE_RELPFUNC;

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -1,6 +1,6 @@
 /* The mapping for relp over TCP.
  *
- * Copyright 2008-2018 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2025 by Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of librelp.
  *
@@ -110,6 +110,7 @@ typedef struct relpTcp_s {
 	relpClt_t *pClt;	   /**< ptr to our client; only valid if pSrv == NULL */
 	unsigned char *pRemHostIP; /**< IP address of remote peer (currently used in server mode, only) */
 	unsigned char *pRemHostName; /**< host name of remote peer (currently used in server mode, only) */
+	unsigned char *pRemHostPort; /**< port of remote peer (currently used in server mode, only) */
 	int sock;	/**< the socket we use for regular, single-socket, operations */
 	int *socks;	/**< the socket(s) we use for listeners, element 0 has nbr of socks */
 	int iSessMax;	/**< maximum number of sessions permitted */


### PR DESCRIPTION
## Summary
- extend engine and TCP structures to track client source port
- add `relpEngineSetSyslogRcv3` API that passes hostname, IP, and port
- invoke new callback when available

## Testing
- `make -j$(nproc)`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68bbf884f07483328ee2e5a0af8b9c1a