### PR TITLE
rhel:Correct the usage of __attribute__

### DIFF
--- a/src/relp.c
+++ b/src/relp.c
@@ -247,7 +247,7 @@ relpEngineDelSess(relpEngine_t *const pThis, relpEngSessLst_t *pSessLstEntry)
  * RELP function. The relp engine must only destructed after all RELP
  * operations have been finished.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineConstruct(relpEngine_t **ppThis)
 {
 	relpEngine_t *pThis;
@@ -281,7 +281,7 @@ finalize_it:
  * Terminates librelp operations, no calls are permitted after engine
  * destruction.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineDestruct(relpEngine_t **ppThis)
 {
 	relpEngine_t *pThis;
@@ -325,7 +325,7 @@ static void dbgprintDummy(char LIBRELP_ATTR_UNUSED *fmt, ...) {}
  * function that already has been set, provide a NULL function pointer.
  * rgerhards, 2008-03-17
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetDbgprint(relpEngine_t *const pThis, void (*dbgprint)(char *fmt, ...) LIBRELP_ATTR_FORMAT(printf, 1, 2))
 {
 	ENTER_RELPFUNC;
@@ -336,7 +336,7 @@ relpEngineSetDbgprint(relpEngine_t *const pThis, void (*dbgprint)(char *fmt, ...
 }
 
 
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetTLSLib(relpEngine_t *const pThis, NOTLS_UNUSED const int tls_lib)
 {
 	ENTER_RELPFUNC;
@@ -375,7 +375,7 @@ finalize_it:
 }
 
 
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetTLSLibByName(relpEngine_t *const pThis, const char *const name)
 {
 	ENTER_RELPFUNC;
@@ -409,7 +409,7 @@ finalize_it:
  * * relgEngineListnerConstructFinalize()
  * rgerhards, 2013-05-14
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineListnerConstruct(relpEngine_t *const pThis, relpSrv_t **ppSrv)
 {
 	relpSrv_t *pSrv;
@@ -422,7 +422,7 @@ relpEngineListnerConstruct(relpEngine_t *const pThis, relpSrv_t **ppSrv)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineListnerConstructFinalize(relpEngine_t *const pThis, relpSrv_t *pSrv)
 {
 	ENTER_RELPFUNC;
@@ -456,7 +456,7 @@ static relpRetVal relpSrvSyslogRcvDummy3(void LIBRELP_ATTR_UNUSED *pUsr,
 /* set the syslog receive callback. If NULL is provided, it is set to the
  * not implemented dummy.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetSyslogRcv2(relpEngine_t *const pThis, relpRetVal (*pCB)(void *, unsigned char*,
        unsigned char*, unsigned char*, size_t))
 {
@@ -472,7 +472,7 @@ relpEngineSetSyslogRcv2(relpEngine_t *const pThis, relpRetVal (*pCB)(void *, uns
 /* set the syslog receive callback. If NULL is provided, it is set to the
  * not implemented dummy.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetSyslogRcv3(relpEngine_t *const pThis, relpRetVal (*pCB)(void *, unsigned char*,
        unsigned char*, unsigned char*, unsigned char*, size_t))
 {
@@ -506,7 +506,7 @@ relpEngineSetSyslogRcv3(relpEngine_t *const pThis, relpRetVal (*pCB)(void *, uns
  * errmsg   - error message as far as librelp is concerned
  * errcode  - contains librelp error status that lead to the failed auth.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetOnAuthErr(relpEngine_t *const pThis, void (*pCB)(void*pUsr, char *authinfo, char*errmsg, relpRetVal errcode) )
 {
 	ENTER_RELPFUNC;
@@ -530,7 +530,7 @@ relpEngineSetOnAuthErr(relpEngine_t *const pThis, void (*pCB)(void*pUsr, char *a
  * errmsg   - error message as far as librelp is concerned
  * errcode  - contains librelp error status
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetOnErr(relpEngine_t *const pThis, void (*pCB)(void*pUsr, char *objinfo, char*errmsg, relpRetVal errcode) )
 {
 	ENTER_RELPFUNC;
@@ -550,7 +550,7 @@ relpEngineSetOnErr(relpEngine_t *const pThis, void (*pCB)(void*pUsr, char *objin
  * errmsg   - error message as far as librelp is concerned
  * errcode  - contains librelp error status
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetOnGenericErr(relpEngine_t *const pThis, void (*pCB)(char *objinfo, char*errmsg, relpRetVal errcode) )
 {
 	ENTER_RELPFUNC;
@@ -562,7 +562,7 @@ relpEngineSetOnGenericErr(relpEngine_t *const pThis, void (*pCB)(char *objinfo, 
 /* Deprecated, use relpEngineListnerConstruct() family of functions.
  * See there for further information.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineAddListner2(relpEngine_t *const pThis, unsigned char *pLstnPort, void *pUsr)
 {
 	relpSrv_t *pSrv = NULL;
@@ -590,7 +590,7 @@ static relpRetVal relpSrvSyslogRcvDummy(unsigned char LIBRELP_ATTR_UNUSED *pHost
 /* set the syslog receive callback. If NULL is provided, it is set to the
  * not implemented dummy.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetSyslogRcv(relpEngine_t *const pThis, relpRetVal (*pCB)(unsigned char*, unsigned char*, unsigned char*, size_t))
 {
 	ENTER_RELPFUNC;
@@ -605,7 +605,7 @@ relpEngineSetSyslogRcv(relpEngine_t *const pThis, relpRetVal (*pCB)(unsigned cha
 /* Deprecated, use relpEngineListnerConstruct() family of functions.
  * See there for further information.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineAddListner(relpEngine_t *const pThis, unsigned char *pLstnPort)
 {
 	relpSrv_t *pSrv = NULL;
@@ -629,7 +629,7 @@ finalize_it:
  * signal is sent, it may take rather long to stop the server (until another
  * machine sends data).
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetStop(relpEngine_t *const pThis)
 {
 	ENTER_RELPFUNC;
@@ -641,7 +641,7 @@ relpEngineSetStop(relpEngine_t *const pThis)
 
 /* set the socket family to use
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetFamily(relpEngine_t *const pThis, int ai_family)
 {
 	ENTER_RELPFUNC;
@@ -1044,7 +1044,7 @@ engineEventLoopRun(relpEngine_t *const pThis)
  * the several flavours of enhanced OS APIs.
  * rgerhards, 2008-03-17
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineRun(relpEngine_t *const pThis)
 {
 	ENTER_RELPFUNC;
@@ -1124,7 +1124,7 @@ finalize_it:
  * users should always call the client-generating functions inside the engine.
  * rgerhards, 2008-03-19
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineCltConstruct(relpEngine_t *const pThis, relpClt_t **ppClt)
 {
 	ENTER_RELPFUNC;
@@ -1143,7 +1143,7 @@ finalize_it:
  * relpEngineCltConstruct(), see comment there for details.
  * rgerhards, 2008-03-19
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineCltDestruct(relpEngine_t *const pThis, relpClt_t **ppClt)
 {
 	ENTER_RELPFUNC;
@@ -1163,11 +1163,7 @@ finalize_it:
  * a configure library entry point check.
  * rgerhards, 2008-03-25
  */
-#ifdef __GNUC__
-	/* somehow gcc-8 always gives as a wrong warning, which we so disable */
-	#pragma GCC diagnostic ignored "-Wattributes"
-#endif
-const char * PART_OF_API
+PART_OF_API const char *
 relpEngineGetVersion(void)
 {
 #	ifdef DEBUG
@@ -1177,7 +1173,7 @@ relpEngineGetVersion(void)
 #	endif
 }
 
-void PART_OF_API
+PART_OF_API void
 relpEngineSetShutdownImmdtPtr(relpEngine_t *const pThis, int *ptr)
 {
 	if(pThis->bShutdownImmdt != ptr)
@@ -1188,7 +1184,7 @@ relpEngineSetShutdownImmdtPtr(relpEngine_t *const pThis, int *ptr)
  * it has been set to forbidden! There will be no error return state in this
  * case. -- rgerhards, 2008-03-27
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetEnableCmd(relpEngine_t *const pThis, unsigned char *pszCmd, relpCmdEnaState_t stateCmd)
 {
 	ENTER_RELPFUNC;
@@ -1212,7 +1208,7 @@ finalize_it:
  * session. If disabled, the IP address will be used as the hostname.
  * rgerhards, 2008-03-31
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpEngineSetDnsLookupMode(relpEngine_t *const pThis, const int iMode)
 {
 	ENTER_RELPFUNC;

--- a/src/relpclt.c
+++ b/src/relpclt.c
@@ -112,7 +112,7 @@ relpCltDestruct(relpClt_t **ppThis)
  * remote servers parameters must already have been set.
  * rgerhards, 2008-03-19
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltConnect(relpClt_t *const pThis, int protFamily, unsigned char *port, unsigned char *host)
 {
 	ENTER_RELPFUNC;
@@ -155,7 +155,7 @@ finalize_it:
  * remote host) can not be changed.
  * rgerhards, 2008-03-23
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltReconnect(relpClt_t *const pThis)
 {
 	ENTER_RELPFUNC;
@@ -172,7 +172,7 @@ finalize_it:
 /** Set the relp window size for this client. Value 0 means
  * that the default value is to be used.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetWindowSize(relpClt_t *const pThis, int sizeWindow)
 {
 	ENTER_RELPFUNC;
@@ -186,7 +186,7 @@ finalize_it:
 }
 
 /** Set the timeout value for this client.  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetTimeout(relpClt_t *const pThis, unsigned timeout)
 {
 	ENTER_RELPFUNC;
@@ -196,7 +196,7 @@ relpCltSetTimeout(relpClt_t *const pThis, unsigned timeout)
 }
 
 /** Set the timeout value for this client socket connection.  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetConnTimeout(relpClt_t *const pThis, int connTimeout)
 {
 	ENTER_RELPFUNC;
@@ -213,7 +213,7 @@ finalize_it:
 
 /** Set the local IP address to be used when acting as a client.
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetClientIP(relpClt_t *const pThis, unsigned char *ipAddr)
 {
 	ENTER_RELPFUNC;
@@ -224,7 +224,7 @@ relpCltSetClientIP(relpClt_t *const pThis, unsigned char *ipAddr)
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltAddPermittedPeer(relpClt_t *const pThis, char *peer)
 {
 	char **newName;
@@ -248,7 +248,7 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetUsrPtr(relpClt_t *const pThis, void *pUsr)
 {
 	ENTER_RELPFUNC;
@@ -258,7 +258,7 @@ relpCltSetUsrPtr(relpClt_t *const pThis, void *pUsr)
 }
 
 /* Note: mode==NULL is valid and means "no change" */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetAuthMode(relpClt_t *const pThis, char *mode)
 {
 	ENTER_RELPFUNC;
@@ -282,7 +282,7 @@ finalize_it:
 /* set the GnuTLS priority string. Providing NULL does re-set
  * any previously set string. -- rgerhards, 2013-06-12
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetGnuTLSPriString(relpClt_t *const pThis, char *pristr)
 {
 	ENTER_RELPFUNC;
@@ -297,7 +297,7 @@ relpCltSetGnuTLSPriString(relpClt_t *const pThis, char *pristr)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetCACert(relpClt_t *const pThis, char *file)
 {
 	ENTER_RELPFUNC;
@@ -312,7 +312,7 @@ relpCltSetCACert(relpClt_t *const pThis, char *file)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetOwnCert(relpClt_t *const pThis, char *file)
 {
 	ENTER_RELPFUNC;
@@ -327,7 +327,7 @@ relpCltSetOwnCert(relpClt_t *const pThis, char *file)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetPrivKey(relpClt_t *const pThis, char *file)
 {
 	ENTER_RELPFUNC;
@@ -342,7 +342,7 @@ relpCltSetPrivKey(relpClt_t *const pThis, char *file)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSetTlsConfigCmd(relpClt_t *const pThis, char *cfgcmd)
 {
 	ENTER_RELPFUNC;
@@ -359,7 +359,7 @@ finalize_it:
 
 }
 /* Enable TLS mode. */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltEnableTLS(relpClt_t *const pThis)
 {
 	ENTER_RELPFUNC;
@@ -368,7 +368,7 @@ relpCltEnableTLS(relpClt_t *const pThis)
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltEnableTLSZip(relpClt_t *const pThis)
 {
 	ENTER_RELPFUNC;
@@ -382,13 +382,13 @@ relpCltEnableTLSZip(relpClt_t *const pThis)
  * The function is intentionally void as it must operate in a way that
  * does not interfere with normal operations.
  */
-void PART_OF_API
+PART_OF_API void
 relpCltHintBurstBegin(relpClt_t *const pThis)
 {
 	relpTcpHintBurstBegin(pThis->pSess->pTcp);
 }
 /* this is the counterpart to relpCltHintBurstBegin -- see there for doc */
-void PART_OF_API
+PART_OF_API void
 relpCltHintBurstEnd(relpClt_t *const pThis)
 {
 	relpTcpHintBurstEnd(pThis->pSess->pTcp);
@@ -399,7 +399,7 @@ relpCltHintBurstEnd(relpClt_t *const pThis)
  * must free it if it is no longer needed.
  * rgerhards, 2008-03-20
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpCltSendSyslog(relpClt_t *const pThis, unsigned char *const pMsg, const size_t lenMsg)
 {
 

--- a/src/relpsrv.c
+++ b/src/relpsrv.c
@@ -122,7 +122,7 @@ relpSrvDestruct(relpSrv_t **ppThis)
  * has been started. In that case, races can happen.
  * rgerhards, 2013-06-18
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvAddPermittedPeer(relpSrv_t *const pThis, char *peer)
 {
 	char **newName;
@@ -150,7 +150,7 @@ finalize_it:
 /* set the user pointer. Whatever value the user provides is accepted.
  * rgerhards, 2008-07-08
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetUsrPtr(relpSrv_t *const pThis, void *pUsr)
 {
 	ENTER_RELPFUNC;
@@ -159,15 +159,16 @@ relpSrvSetUsrPtr(relpSrv_t *const pThis, void *pUsr)
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal PART_OF_API
-relpSrvSetMaxDataSize(relpSrv_t *const pThis, size_t maxSize) {
+PART_OF_API relpRetVal
+relpSrvSetMaxDataSize(relpSrv_t *const pThis, size_t maxSize)
+{
 	ENTER_RELPFUNC;
 	RELPOBJ_assert(pThis, Srv);
 	pThis->maxDataSize = maxSize;
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal PART_OF_API LIBRELP_ATTR_NONNULL()
+PART_OF_API relpRetVal LIBRELP_ATTR_NONNULL()
 relpSrvSetOversizeMode(relpSrv_t *const pThis, const int oversizeMode)
 {
 	ENTER_RELPFUNC;
@@ -187,7 +188,7 @@ finalize_it:
  * free the passed-in string.
  * rgerhards, 2008-03-17
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetLstnPort(relpSrv_t *const pThis, unsigned char *pLstnPort)
 {
 	ENTER_RELPFUNC;
@@ -211,7 +212,7 @@ finalize_it:
  * free the passed-in string.
  * perlei, 2018-04-19
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetLstnAddr(relpSrv_t *const pThis, unsigned char *pLstnAddr)
 {
 	ENTER_RELPFUNC;
@@ -231,7 +232,7 @@ finalize_it:
 }
 
 /* mode==NULL is valid and means "no change" */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetAuthMode(relpSrv_t *const pThis, char *mode)
 {
 	ENTER_RELPFUNC;
@@ -267,7 +268,7 @@ relpSrvSetFamily(relpSrv_t *const pThis, int ai_family)
 /* set the GnuTLS priority string. Providing NULL does re-set
  * any previously set string. -- rgerhards, 2013-06-12
  */
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetGnuTLSPriString(relpSrv_t *const pThis, char *pristr)
 {
 	ENTER_RELPFUNC;
@@ -283,7 +284,7 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetCACert(relpSrv_t *const pThis, char *cert)
 {
 	ENTER_RELPFUNC;
@@ -298,7 +299,7 @@ relpSrvSetCACert(relpSrv_t *const pThis, char *cert)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetOwnCert(relpSrv_t *const pThis, char *cert)
 {
 	ENTER_RELPFUNC;
@@ -313,7 +314,7 @@ relpSrvSetOwnCert(relpSrv_t *const pThis, char *cert)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetPrivKey(relpSrv_t *const pThis, char *cert)
 {
 	ENTER_RELPFUNC;
@@ -329,7 +330,7 @@ finalize_it:
 	LEAVE_RELPFUNC;
 }
 
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvSetTlsConfigCmd(relpSrv_t *const pThis, char *cfgcmd)
 {
 	ENTER_RELPFUNC;
@@ -344,12 +345,12 @@ relpSrvSetTlsConfigCmd(relpSrv_t *const pThis, char *cfgcmd)
 finalize_it:
 	LEAVE_RELPFUNC;
 }
-void PART_OF_API
+PART_OF_API void
 relpSrvSetDHBits(relpSrv_t *const pThis, int bits)
 {
 	pThis->dhBits = bits;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvEnableTLS2(relpSrv_t LIBRELP_ATTR_UNUSED *pThis)
 {
 	ENTER_RELPFUNC;
@@ -360,7 +361,7 @@ relpSrvEnableTLS2(relpSrv_t LIBRELP_ATTR_UNUSED *pThis)
 #endif /* #ifdef ENABLE_TLS | ENABLE_TLS_OPENSSL */
 	LEAVE_RELPFUNC;
 }
-relpRetVal PART_OF_API
+PART_OF_API relpRetVal
 relpSrvEnableTLSZip2(relpSrv_t LIBRELP_ATTR_UNUSED *pThis)
 {
 	ENTER_RELPFUNC;
@@ -371,18 +372,18 @@ relpSrvEnableTLSZip2(relpSrv_t LIBRELP_ATTR_UNUSED *pThis)
 #endif /* #ifdef ENABLE_TLS | ENABLE_TLS_OPENSSL */
 	LEAVE_RELPFUNC;
 }
-void PART_OF_API
+PART_OF_API void
 relpSrvEnableTLS(relpSrv_t *const pThis)
 {
 	relpSrvEnableTLS2(pThis);
 }
-void PART_OF_API
+PART_OF_API void
 relpSrvEnableTLSZip(relpSrv_t *const pThis)
 {
 	relpSrvEnableTLSZip2(pThis);
 }
 
-void PART_OF_API
+PART_OF_API void
 relpSrvSetKeepAlive(relpSrv_t *const pThis,
 	const int bEnabled,
 	const int iKeepAliveIntvl,


### PR DESCRIPTION
Signed-off-by: zhangzikang01 <zhangzikang@kylinos.cn>

Comparison of the librelp-1.2.16 version reveals that the librelp.so.0 library generated by compiling the current version of the source code no longer includes the relpEngineGetVersion symbol, which does not meet compatibility requirements. Therefore, an analysis of the source code was conducted.

The analysis found that in the Makefile.am file, "AM_CFLAGS=-fvisibility=hidden" was added, setting the default attribute to hidden. Then, during function definition, the attribute was modified to default via "attribute((visibility("default")))". However, modifying the attribute to default at the definition location of the relpEngineGetVersion function did not take effect. The relpEngineGetVersion function retained the hidden attribute, resulting in the absence of the relpEngineGetVersion symbol in the compiled librelp.so.0 library.

Consult the information in the following link:
https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html

The material indicates that for functions, the __attribute__ should be placed either before the declaration type or at the very end of the function.

A test demo was written to verify the usage of __attribute__:
-----------------------------------
#include <stdio.h>

#define PART_OF_API __attribute__((visibility("default")))
#define VERSION "1.11.0"
#define CH 't'

const char * test_0(void)
{
        return (char*) (VERSION);
}

const char * PART_OF_API test_1(void)
{
        return (char*) (VERSION);
}

PART_OF_API const char * test_2(void)
{
        return (char*) (VERSION);
}

void main()
{
        printf("test!\n");
}
-----------------------------------
# gcc -fvisibility=hidden test.c -o libtest.o
test.c:13:1: warning: the 'visibility' attribute is ignored on a non-class type [-Wattributes]
   13 | {
      | ^

# readelf -sW libtest.o | grep test_
    70: 0000000000400690    12 FUNC    GLOBAL HIDDEN    13 test_1
    81: 000000000040069c    12 FUNC    GLOBAL DEFAULT   13 test_2
    86: 0000000000400684    12 FUNC    GLOBAL HIDDEN    13 test_0
-----------------------------------

Based on the test results, it was found that:

(1) Without adding __attribute__((visibility("default"))):  the attribute remains hidden.
(2) Adding __attribute__((visibility("default"))) before the declaration type: the attribute is successfully modified to default.
(3) Adding __attribute__((visibility("default"))) between the declaration type and the function name: the attribute modification does not take effect, remains hidden, and a warning is generated (though warning messages are suppressed in the source code: #pragma GCC diagnostic ignored "-Wattributes").

Therefore, it is preliminarily determined that the incorrect placement of __attribute__((visibility("default"))) caused the attribute modification to fail. Hence, this PR is submitted to address the issue.