### PR TITLE
gitignore: ignore local Codex agent notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ tmptmp
 *.o
 *.lo
 *.gz
+
+# Local machine-specific Codex notes
+AGENTS.local.md


### PR DESCRIPTION
## Summary
- Ignore `AGENTS.local.md` for machine-specific Codex notes.

## Testing
- Not run; ignore-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore AGENTS.local.md to keep machine-specific Codex notes out of version control and prevent accidental commits.

<sup>Written for commit e182aa65bb6ed144acfb894cc92352f6deaca5da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

